### PR TITLE
Fix gradient variables usage and remove unused selectors

### DIFF
--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -27,8 +27,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
 // gradient colors
 document.addEventListener("DOMContentLoaded", () => {
-    const bodyBefore = document.querySelector("body::before");
-    const bodyAfter = document.querySelector("body::after");
 
     const gradients = [
         ["#000000", "#020c1b", "#0a1f44", "#273a7f"], // Deep blue night

--- a/client/styles/home.css
+++ b/client/styles/home.css
@@ -1,5 +1,5 @@
 body {
-  background: linear-gradient(to bottom, #000000, #001f3f, #3d0075, #4b0082);
+  background: var(--gradient-current, linear-gradient(to bottom, #000000, #001f3f, #3d0075, #4b0082));
   display: flex;
   justify-content: center;
   align-items: center;

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -7,11 +7,11 @@ body {
     height: 100vh;
     overflow: hidden;
     position: relative;
-    background: linear-gradient(to bottom, #000000, #290136, #400144, #290136, #020131);
+    background: var(--gradient-current, linear-gradient(to bottom, #000000, #290136, #400144, #290136, #020131));
     transition: background 1.5s ease-in-out;
 }
 
-body::before, 
+body::before,
 body::after {
     content: "";
     position: absolute;
@@ -22,6 +22,10 @@ body::after {
     opacity: 0;
     transition: opacity 2s ease-in-out;
     pointer-events: none;
+}
+
+body::after {
+    background: var(--gradient-next);
 }
 
 @keyframes fadeGradient {


### PR DESCRIPTION
## Summary
- drop references to `body::before` and `body::after` from JS
- apply `--gradient-current` and `--gradient-next` CSS variables
- update home page stylesheet for the new gradient variable

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684630299ae483259b478aac382d17f0