### PR TITLE
Add simple Node server for npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-﻿# Elysium Web - Under construction
+# Elysium Web
+
+This repository contains the static assets for the Elysium Web project. The `client/` directory holds the HTML, CSS and JavaScript that make up the site.
+
+## Running locally
+
+A small Node server is included to serve the contents of `client/` for development. Run the following commands:
+
+```bash
+npm start
+```
+
+This will start a server on [http://localhost:3000](http://localhost:3000). No additional dependencies are required.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "elysium-web",
+  "version": "1.0.0",
+  "description": "Static website for Elysium Web",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,50 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, 'client');
+const port = process.env.PORT || 3000;
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2'
+};
+
+function serveFile(filePath, res) {
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = mimeTypes[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(content);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  let filePath = path.join(root, req.url);
+  if (req.url === '/' || req.url.endsWith('/')) {
+    filePath = path.join(root, req.url, 'index.html');
+  }
+  fs.stat(filePath, (err, stats) => {
+    if (!err && stats.isDirectory()) {
+      filePath = path.join(filePath, 'index.html');
+    }
+    serveFile(filePath, res);
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add a basic HTTP server using Node to serve `client/`
- include `package.json` with `start` script
- update README with instructions for running the server

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68463229c84883259ce9c80aa7fb830b