### PR TITLE
Improve background gradient transition

### DIFF
--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -45,6 +45,7 @@ document.addEventListener("DOMContentLoaded", () => {
     ];
 
     let currentGradientIndex = 0;
+    const fadeDuration = 2000; // match CSS transition duration
     function updateGradients() {
         const nextGradientIndex = (currentGradientIndex + 1) % gradients.length;
         const currentColors = gradients[currentGradientIndex];
@@ -59,7 +60,16 @@ document.addEventListener("DOMContentLoaded", () => {
             `linear-gradient(to bottom, ${nextColors[0]}, ${nextColors[1]}, ${nextColors[2]}, ${nextColors[3]})`
         );
 
-        currentGradientIndex = nextGradientIndex;
+        // Trigger crossfade
+        document.body.classList.add("fade-gradient");
+        setTimeout(() => {
+            document.body.style.setProperty(
+                "--gradient-current",
+                `linear-gradient(to bottom, ${nextColors[0]}, ${nextColors[1]}, ${nextColors[2]}, ${nextColors[3]})`
+            );
+            document.body.classList.remove("fade-gradient");
+            currentGradientIndex = nextGradientIndex;
+        }, fadeDuration);
     }
     updateGradients();
     setInterval(updateGradients, 60000);

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -34,6 +34,10 @@ body::after {
     background: var(--gradient-next);
 }
 
+body.fade-gradient::after {
+    opacity: 1;
+}
+
 @keyframes fadeGradient {
     0% { opacity: 1; }
     50% { opacity: 0; }


### PR DESCRIPTION
## Summary
- crossfade background gradient colors using a pseudo-element
- trigger gradient fades in `background.js` for smoother transitions

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684b815c0ff48325ba95af4b2ef57906