### PR TITLE
Centralize emotion metadata types

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ The compiled JavaScript will appear in `build/` using the configuration in
 Planetary names are stored in `src/data/realmMetadata.ts`. Each entry defines a realm
 by name and is used across the React pages to generate the planetary views.
 
+Emotion clusters for each realm live in `src/data/clusters/`. Their matching core
+planets are listed in `src/data/planets/`. The shared interfaces `EmotionCluster`
+and `CorePlanet` reside in `src/data/types.ts` so these structures stay consistent.
+
 ## Exploring the Universe demo
 
 After logging in you can navigate to the planetary view by clicking **Begin Your Journey**. The page `pages/universe.html` lets you create short posts tied to an emotion. As people react with different emotions, each post will migrate to the planet that best represents the community response.

--- a/src/components/RealmTemplate.tsx
+++ b/src/components/RealmTemplate.tsx
@@ -1,8 +1,4 @@
-
-export interface CorePlanet {
-  name: string
-  emotion: string
-}
+import { CorePlanet } from '../data/types'
 
 export interface RealmTemplateProps {
   realmName: string

--- a/src/data/clusters/abyss.ts
+++ b/src/data/clusters/abyss.ts
@@ -1,27 +1,24 @@
-export interface EmotionCluster {
-  name: string
-  emotions: string[]
-}
+import { EmotionCluster } from '../types'
 
 export const clusters: EmotionCluster[] = [
   {
     name: 'Silent Chase',
-    emotions: ['fear', 'anxiety', 'suspicion', 'dread']
+    emotions: ['fear', 'anxiety', 'suspicion', 'dread'],
   },
   {
     name: 'Hollow Veil',
-    emotions: ['emptiness', 'numbness', 'dysregulation', 'isolated']
+    emotions: ['emptiness', 'numbness', 'dysregulation', 'isolated'],
   },
   {
     name: 'Frozen Nerve',
-    emotions: ['panic', 'disoriented', 'overwhelmed', 'paranoia']
+    emotions: ['panic', 'disoriented', 'overwhelmed', 'paranoia'],
   },
   {
     name: 'Bound Breath',
-    emotions: ['helplessness', 'collapse', 'suffocation', 'powerlessness']
+    emotions: ['helplessness', 'collapse', 'suffocation', 'powerlessness'],
   },
   {
     name: 'Null Horizon',
-    emotions: ['hopelessness', 'despair', 'derealization', 'meaninglessness']
-  }
+    emotions: ['hopelessness', 'despair', 'derealization', 'meaninglessness'],
+  },
 ]

--- a/src/data/clusters/cavern.ts
+++ b/src/data/clusters/cavern.ts
@@ -1,27 +1,24 @@
-export interface EmotionCluster {
-  name: string
-  emotions: string[]
-}
+import { EmotionCluster } from '../types'
 
 export const clusters: EmotionCluster[] = [
   {
     name: 'False Shrine',
-    emotions: ['idolization', 'obsession', 'projection', 'dependence']
+    emotions: ['idolization', 'obsession', 'projection', 'dependence'],
   },
   {
     name: 'Smoky Mirror',
-    emotions: ['envy', 'inferiority', 'superiority', 'imposter syndrome']
+    emotions: ['envy', 'inferiority', 'superiority', 'imposter syndrome'],
   },
   {
     name: 'Venom Hold',
-    emotions: ['jealousy', 'insecure', 'possessive', 'clingy', 'territorial']
+    emotions: ['jealousy', 'insecure', 'possessive', 'clingy', 'territorial'],
   },
   {
     name: 'Itchy Bite',
-    emotions: ['bitterness', 'resentment', 'spite', 'pettiness']
+    emotions: ['bitterness', 'resentment', 'spite', 'pettiness'],
   },
   {
     name: 'Spiky Throne',
-    emotions: ['contempt', 'entitlement', 'judgmental', 'smug']
-  }
+    emotions: ['contempt', 'entitlement', 'judgmental', 'smug'],
+  },
 ]

--- a/src/data/clusters/dross.ts
+++ b/src/data/clusters/dross.ts
@@ -1,23 +1,20 @@
-export interface EmotionCluster {
-  name: string
-  emotions: string[]
-}
+import { EmotionCluster } from '../types'
 
 export const clusters: EmotionCluster[] = [
   {
     name: 'Putrid Force',
-    emotions: ['disgust', 'repulsion', 'revulsion']
+    emotions: ['disgust', 'repulsion', 'revulsion'],
   },
   {
     name: 'Tarry Bone',
-    emotions: ['self-loathing', 'unclean', 'stained', 'contaminated']
+    emotions: ['self-loathing', 'unclean', 'stained', 'contaminated'],
   },
   {
     name: 'Stolen Doll',
-    emotions: ['violated', 'dehumanized', 'fetishized', 'used', 'exploited']
+    emotions: ['violated', 'dehumanized', 'fetishized', 'used', 'exploited'],
   },
   {
     name: 'Pale Shiver',
-    emotions: ['malaise', 'nauseated', 'itchy', 'sweaty', 'stinky']
-  }
+    emotions: ['malaise', 'nauseated', 'itchy', 'sweaty', 'stinky'],
+  },
 ]

--- a/src/data/clusters/ember.ts
+++ b/src/data/clusters/ember.ts
@@ -1,23 +1,36 @@
-export interface EmotionCluster {
-  name: string
-  emotions: string[]
-}
+import { EmotionCluster } from '../types'
 
 export const clusters: EmotionCluster[] = [
   {
     name: 'Infernal Mammoth',
-    emotions: ['rage', 'indignant', 'berserk', 'smoldering', 'destructive']
+    emotions: ['rage', 'indignant', 'berserk', 'smoldering', 'destructive'],
   },
   {
     name: 'Brazen Rhino',
-    emotions: ['reckless', 'audacity', 'thrill-seeking', 'impulsive', 'daring']
+    emotions: ['reckless', 'audacity', 'thrill-seeking', 'impulsive', 'daring'],
   },
   {
     name: 'Noisy Wasp',
-    emotions: ['frustrated', 'irritated', 'impatient', 'agitated', 'overthinking', 'hypervigilant', 'restless']
+    emotions: [
+      'frustrated',
+      'irritated',
+      'impatient',
+      'agitated',
+      'overthinking',
+      'hypervigilant',
+      'restless',
+    ],
   },
   {
     name: 'Vicious Cobra',
-    emotions: ['aggressive', 'confrontational', 'defiant', 'hostile', 'provocative', 'rebellious', 'combative']
-  }
+    emotions: [
+      'aggressive',
+      'confrontational',
+      'defiant',
+      'hostile',
+      'provocative',
+      'rebellious',
+      'combative',
+    ],
+  },
 ]

--- a/src/data/clusters/glare.ts
+++ b/src/data/clusters/glare.ts
@@ -1,19 +1,16 @@
-export interface EmotionCluster {
-  name: string
-  emotions: string[]
-}
+import { EmotionCluster } from '../types'
 
 export const clusters: EmotionCluster[] = [
   {
     name: 'Fractured Stage',
-    emotions: ['shame', 'humiliation', 'exposure', 'unworthiness']
+    emotions: ['shame', 'humiliation', 'exposure', 'unworthiness'],
   },
   {
     name: 'Deadlight Hall',
-    emotions: ['repressed', 'tension', 'avoidance', 'self-denial']
+    emotions: ['repressed', 'tension', 'avoidance', 'self-denial'],
   },
   {
     name: 'Glaring Eye',
-    emotions: ['judged', 'mocked', 'spotlighted', 'accused']
-  }
+    emotions: ['judged', 'mocked', 'spotlighted', 'accused'],
+  },
 ]

--- a/src/data/clusters/languish.ts
+++ b/src/data/clusters/languish.ts
@@ -1,23 +1,20 @@
-export interface EmotionCluster {
-  name: string
-  emotions: string[]
-}
+import { EmotionCluster } from '../types'
 
 export const clusters: EmotionCluster[] = [
   {
     name: 'Glass Crypt',
-    emotions: ['despair', 'hopelessness', 'exhaustion', 'burnout', 'resignation']
+    emotions: ['despair', 'hopelessness', 'exhaustion', 'burnout', 'resignation'],
   },
   {
     name: 'Blank Prism',
-    emotions: ['numbness', 'lost', 'disconnected', 'detached', 'shut down']
+    emotions: ['numbness', 'lost', 'disconnected', 'detached', 'shut down'],
   },
   {
     name: 'Sapphire Chamber',
-    emotions: ['grief', 'sorrow', 'mourning', 'heartache']
+    emotions: ['grief', 'sorrow', 'mourning', 'heartache'],
   },
   {
     name: 'Empty House',
-    emotions: ['isolation', 'unreachable', 'abandoned', 'unseen']
-  }
+    emotions: ['isolation', 'unreachable', 'abandoned', 'unseen'],
+  },
 ]

--- a/src/data/clusters/mist.ts
+++ b/src/data/clusters/mist.ts
@@ -1,27 +1,24 @@
-export interface EmotionCluster {
-  name: string
-  emotions: string[]
-}
+import { EmotionCluster } from '../types'
 
 export const clusters: EmotionCluster[] = [
   {
     name: 'Lucid Thread',
-    emotions: ['curious', 'intrigue', 'spark', 'suspense']
+    emotions: ['curious', 'intrigue', 'spark', 'suspense'],
   },
   {
     name: 'Ancient Quiet',
-    emotions: ['awe', 'wonder', 'reverence', 'timelessness']
+    emotions: ['awe', 'wonder', 'reverence', 'timelessness'],
   },
   {
     name: 'Fractal Maze',
-    emotions: ['confusion', 'ambiguity', 'unease', 'lost', 'disoriented', 'bewildered']
+    emotions: ['confusion', 'ambiguity', 'unease', 'lost', 'disoriented', 'bewildered'],
   },
   {
     name: 'Shallow Anchor',
-    emotions: ['doubt', 'skeptical', 'suspicious', 'distrust', 'second guessing']
+    emotions: ['doubt', 'skeptical', 'suspicious', 'distrust', 'second guessing'],
   },
   {
     name: 'Myriad Glitch',
-    emotions: ['surreal', 'uncanny', 'absurd', 'nonsensical', 'paradoxical']
-  }
+    emotions: ['surreal', 'uncanny', 'absurd', 'nonsensical', 'paradoxical'],
+  },
 ]

--- a/src/data/clusters/oasis.ts
+++ b/src/data/clusters/oasis.ts
@@ -1,35 +1,54 @@
-export interface EmotionCluster {
-  name: string
-  emotions: string[]
-}
+import { EmotionCluster } from '../types'
 
 export const clusters: EmotionCluster[] = [
   {
     name: 'Verdant Hearth',
-    emotions: ['safe', 'hydrated', 'rested', 'regulated', 'full', 'healthy', 'content']
+    emotions: ['safe', 'hydrated', 'rested', 'regulated', 'full', 'healthy', 'content'],
   },
   {
     name: 'Radiant Grove',
-    emotions: ['joy', 'delighted', 'uplifted', 'beaming', 'radiant', 'ecstatic', 'excited']
+    emotions: [
+      'joy',
+      'delighted',
+      'uplifted',
+      'beaming',
+      'radiant',
+      'ecstatic',
+      'excited',
+    ],
   },
   {
     name: 'Honey Bloom',
-    emotions: ['love', 'affectionate', 'compassionate', 'nurtured', 'endearing', 'tender']
+    emotions: [
+      'love',
+      'affectionate',
+      'compassionate',
+      'nurtured',
+      'endearing',
+      'tender',
+    ],
   },
   {
     name: 'Open Palm',
-    emotions: ['grateful', 'fortunate', 'acknowledged', 'cherished', 'accepted', 'received']
+    emotions: [
+      'grateful',
+      'fortunate',
+      'acknowledged',
+      'cherished',
+      'accepted',
+      'received',
+    ],
   },
   {
     name: 'Woven Circle',
-    emotions: ['belonging', 'centered', 'rooted', 'anchored', 'grounded', 'connected']
+    emotions: ['belonging', 'centered', 'rooted', 'anchored', 'grounded', 'connected'],
   },
   {
     name: 'Twinkle Toe',
-    emotions: ['playful', 'carefree', 'lighthearted', 'amused', 'silly', 'giddy']
+    emotions: ['playful', 'carefree', 'lighthearted', 'amused', 'silly', 'giddy'],
   },
   {
     name: 'Soft Meadow',
-    emotions: ['peace', 'serene', 'tranquil', 'ease', 'untroubled', 'calm']
-  }
+    emotions: ['peace', 'serene', 'tranquil', 'ease', 'untroubled', 'calm'],
+  },
 ]

--- a/src/data/clusters/trace.ts
+++ b/src/data/clusters/trace.ts
@@ -1,23 +1,27 @@
-export interface EmotionCluster {
-  name: string
-  emotions: string[]
-}
+import { EmotionCluster } from '../types'
 
 export const clusters: EmotionCluster[] = [
   {
     name: 'Sepia Garden',
-    emotions: ['nostalgia', 'sentimental', 'familiarity', 'reminiscing', 'reflecting', 'pondering']
+    emotions: [
+      'nostalgia',
+      'sentimental',
+      'familiarity',
+      'reminiscing',
+      'reflecting',
+      'pondering',
+    ],
   },
   {
     name: 'Word Cemetery',
-    emotions: ['regret', 'guilt', 'incompletion', 'lingering', 'aching']
+    emotions: ['regret', 'guilt', 'incompletion', 'lingering', 'aching'],
   },
   {
     name: 'Aurora Shadow',
-    emotions: ['yearning', 'craving', 'wistful', 'bittersweet', 'homesick']
+    emotions: ['yearning', 'craving', 'wistful', 'bittersweet', 'homesick'],
   },
   {
     name: 'Butterfly Canopy',
-    emotions: ['daydreaming', 'drifting', 'imagining', 'musing', 'contemplating']
-  }
+    emotions: ['daydreaming', 'drifting', 'imagining', 'musing', 'contemplating'],
+  },
 ]

--- a/src/data/clusters/zenith.ts
+++ b/src/data/clusters/zenith.ts
@@ -1,23 +1,20 @@
-export interface EmotionCluster {
-  name: string
-  emotions: string[]
-}
+import { EmotionCluster } from '../types'
 
 export const clusters: EmotionCluster[] = [
   {
     name: 'Steadfast Anvil',
-    emotions: ['endurance', 'resilient', 'disciplined', 'fortified', 'resolve']
+    emotions: ['endurance', 'resilient', 'disciplined', 'fortified', 'resolve'],
   },
   {
     name: 'Primordial Pillar',
-    emotions: ['pride', 'dignity', 'integrity', 'trustworthy', 'reputable']
+    emotions: ['pride', 'dignity', 'integrity', 'trustworthy', 'reputable'],
   },
   {
     name: 'Luminescent Crown',
-    emotions: ['empowered', 'confident', 'inspired', 'triumphant', 'strong-willed']
+    emotions: ['empowered', 'confident', 'inspired', 'triumphant', 'strong-willed'],
   },
   {
     name: 'Omega Threshold',
-    emotions: ['liberation', 'elevation', 'release', 'awakening', 'eureka']
-  }
+    emotions: ['liberation', 'elevation', 'release', 'awakening', 'eureka'],
+  },
 ]

--- a/src/data/planets/abyss.ts
+++ b/src/data/planets/abyss.ts
@@ -1,12 +1,9 @@
-export interface CorePlanet {
-  name: string
-  emotion: string
-}
+import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
   { name: 'Nocturnis', emotion: 'fear' },
   { name: 'Thalix', emotion: 'helplessness' },
   { name: 'Umbrak', emotion: 'emptiness' },
   { name: 'Abyzeth', emotion: 'hopelessness' },
-  { name: 'Nerveris', emotion: 'panic' }
+  { name: 'Nerveris', emotion: 'panic' },
 ]

--- a/src/data/planets/cavern.ts
+++ b/src/data/planets/cavern.ts
@@ -1,12 +1,9 @@
-export interface CorePlanet {
-  name: string
-  emotion: string
-}
+import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
   { name: 'Kerelos', emotion: 'jealousy' },
   { name: 'Thirsa', emotion: 'envy' },
   { name: 'Bedesto', emotion: 'idolization' },
   { name: 'Varkir', emotion: 'bitterness' },
-  { name: 'Tharnis', emotion: 'contempt' }
+  { name: 'Tharnis', emotion: 'contempt' },
 ]

--- a/src/data/planets/dross.ts
+++ b/src/data/planets/dross.ts
@@ -1,11 +1,8 @@
-export interface CorePlanet {
-  name: string
-  emotion: string
-}
+import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
   { name: 'Graskul', emotion: 'disgust' },
   { name: 'Exulith', emotion: 'self-loathing' },
   { name: 'Trocita', emotion: 'violated' },
-  { name: 'Ofoki', emotion: 'malaise' }
+  { name: 'Ofoki', emotion: 'malaise' },
 ]

--- a/src/data/planets/ember.ts
+++ b/src/data/planets/ember.ts
@@ -1,12 +1,8 @@
-export interface CorePlanet {
-  name: string
-  emotion: string
-  satellites?: string[]
-}
+import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
   { name: 'Agnera', emotion: 'frustrated' },
   { name: 'Fureza', emotion: 'rage', satellites: ['wrath', 'fury'] },
   { name: 'Romana', emotion: 'reckless' },
-  { name: 'Provota', emotion: 'aggressive' }
+  { name: 'Provota', emotion: 'aggressive' },
 ]

--- a/src/data/planets/glare.ts
+++ b/src/data/planets/glare.ts
@@ -1,10 +1,7 @@
-export interface CorePlanet {
-  name: string
-  emotion: string
-}
+import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
   { name: 'Rassembar', emotion: 'shame' },
   { name: 'Censyr', emotion: 'repressed' },
-  { name: 'Tawnter', emotion: 'humiliated' }
+  { name: 'Tawnter', emotion: 'humiliated' },
 ]

--- a/src/data/planets/languish.ts
+++ b/src/data/planets/languish.ts
@@ -1,11 +1,8 @@
-export interface CorePlanet {
-  name: string
-  emotion: string
-}
+import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
   { name: 'Trosta', emotion: 'grief' },
   { name: 'Sedra', emotion: 'numb' },
   { name: 'Dolenza', emotion: 'despair' },
-  { name: 'Estrana', emotion: 'isolation' }
+  { name: 'Estrana', emotion: 'isolation' },
 ]

--- a/src/data/planets/mist.ts
+++ b/src/data/planets/mist.ts
@@ -1,12 +1,9 @@
-export interface CorePlanet {
-  name: string
-  emotion: string
-}
+import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
   { name: 'Obsceris', emotion: 'confusion' },
   { name: 'Dysira', emotion: 'doubt' },
   { name: 'Verio', emotion: 'curiosity' },
   { name: 'Zonder', emotion: 'awe' },
-  { name: 'Umbranova', emotion: 'surreal' }
+  { name: 'Umbranova', emotion: 'surreal' },
 ]

--- a/src/data/planets/oasis.ts
+++ b/src/data/planets/oasis.ts
@@ -1,7 +1,4 @@
-export interface CorePlanet {
-  name: string
-  emotion: string
-}
+import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
   { name: 'Allora', emotion: 'belonging' },
@@ -10,5 +7,5 @@ export const corePlanets: CorePlanet[] = [
   { name: 'Merulo', emotion: 'safe' },
   { name: 'Solene', emotion: 'joy' },
   { name: 'Vivaly', emotion: 'playful' },
-  { name: 'Gawyn', emotion: 'grateful' }
+  { name: 'Gawyn', emotion: 'grateful' },
 ]

--- a/src/data/planets/trace.ts
+++ b/src/data/planets/trace.ts
@@ -1,11 +1,8 @@
-export interface CorePlanet {
-  name: string
-  emotion: string
-}
+import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
   { name: 'Yorell', emotion: 'nostalgia' },
   { name: 'Renmor', emotion: 'regret' },
   { name: 'Fenric', emotion: 'yearning' },
-  { name: 'Drisano', emotion: 'daydreaming' }
+  { name: 'Drisano', emotion: 'daydreaming' },
 ]

--- a/src/data/planets/zenith.ts
+++ b/src/data/planets/zenith.ts
@@ -1,11 +1,8 @@
-export interface CorePlanet {
-  name: string
-  emotion: string
-}
+import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
   { name: 'Kalyra', emotion: 'empowerment' },
   { name: 'Eladon', emotion: 'pride' },
   { name: 'Zepharel', emotion: 'liberation' },
-  { name: 'Milenios', emotion: 'endurance' }
+  { name: 'Milenios', emotion: 'endurance' },
 ]

--- a/src/data/realmMetadata.ts
+++ b/src/data/realmMetadata.ts
@@ -12,5 +12,5 @@ export const realms: Record<string, RealmMeta> = {
   mist: { realmName: 'Mist' },
   oasis: { realmName: 'Oasis' },
   trace: { realmName: 'Trace' },
-  zenith: { realmName: 'Zenith' }
+  zenith: { realmName: 'Zenith' },
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,0 +1,10 @@
+export interface EmotionCluster {
+  name: string
+  emotions: string[]
+}
+
+export interface CorePlanet {
+  name: string
+  emotion: string
+  satellites?: string[]
+}


### PR DESCRIPTION
## Summary
- add `src/data/types.ts` for `EmotionCluster` and `CorePlanet`
- refactor all cluster and planet data files to import shared types
- use the shared `CorePlanet` type in `RealmTemplate`
- document the data files in the README
- show my love in the commit history

## Testing
- `npm run format`
- `npm test`
- `npm run build` *(fails: Cannot find namespace 'React')*

------
https://chatgpt.com/codex/tasks/task_e_684dcff070408325bb07d87cf07b9f64