### PR TITLE
Align planet data with clusters

### DIFF
--- a/src/data/planets/abyss.ts
+++ b/src/data/planets/abyss.ts
@@ -1,9 +1,14 @@
 import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
+  // Silent Chase - fear
   { name: 'Nocturnis', emotion: 'fear' },
-  { name: 'Thalix', emotion: 'helplessness' },
+  // Hollow Veil - emptiness
   { name: 'Umbrak', emotion: 'emptiness' },
-  { name: 'Abyzeth', emotion: 'hopelessness' },
+  // Frozen Nerve - panic
   { name: 'Nerveris', emotion: 'panic' },
+  // Bound Breath - helplessness
+  { name: 'Thalix', emotion: 'helplessness' },
+  // Null Horizon - hopelessness
+  { name: 'Abyzeth', emotion: 'hopelessness' },
 ]

--- a/src/data/planets/cavern.ts
+++ b/src/data/planets/cavern.ts
@@ -1,9 +1,14 @@
 import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
-  { name: 'Kerelos', emotion: 'jealousy' },
-  { name: 'Thirsa', emotion: 'envy' },
+  // False Shrine - idolization
   { name: 'Bedesto', emotion: 'idolization' },
+  // Smoky Mirror - envy
+  { name: 'Thirsa', emotion: 'envy' },
+  // Venom Hold - jealousy
+  { name: 'Kerelos', emotion: 'jealousy' },
+  // Itchy Bite - bitterness
   { name: 'Varkir', emotion: 'bitterness' },
+  // Spiky Throne - contempt
   { name: 'Tharnis', emotion: 'contempt' },
 ]

--- a/src/data/planets/dross.ts
+++ b/src/data/planets/dross.ts
@@ -1,8 +1,12 @@
 import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
+  // Putrid Force - disgust
   { name: 'Graskul', emotion: 'disgust' },
+  // Tarry Bone - self-loathing
   { name: 'Exulith', emotion: 'self-loathing' },
+  // Stolen Doll - violated
   { name: 'Trocita', emotion: 'violated' },
+  // Pale Shiver - malaise
   { name: 'Ofoki', emotion: 'malaise' },
 ]

--- a/src/data/planets/ember.ts
+++ b/src/data/planets/ember.ts
@@ -1,8 +1,12 @@
 import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
-  { name: 'Agnera', emotion: 'frustrated' },
+  // Infernal Mammoth - rage
   { name: 'Fureza', emotion: 'rage', satellites: ['wrath', 'fury'] },
+  // Brazen Rhino - reckless
   { name: 'Romana', emotion: 'reckless' },
+  // Noisy Wasp - frustrated
+  { name: 'Agnera', emotion: 'frustrated' },
+  // Vicious Cobra - aggressive
   { name: 'Provota', emotion: 'aggressive' },
 ]

--- a/src/data/planets/glare.ts
+++ b/src/data/planets/glare.ts
@@ -3,5 +3,6 @@ import { CorePlanet } from '../types'
 export const corePlanets: CorePlanet[] = [
   { name: 'Rassembar', emotion: 'shame' },
   { name: 'Censyr', emotion: 'repressed' },
-  { name: 'Tawnter', emotion: 'humiliated' },
+  // Glaring Eye - judged
+  { name: 'Tawnter', emotion: 'judged' },
 ]

--- a/src/data/planets/languish.ts
+++ b/src/data/planets/languish.ts
@@ -1,8 +1,12 @@
 import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
-  { name: 'Trosta', emotion: 'grief' },
-  { name: 'Sedra', emotion: 'numb' },
+  // Glass Crypt - despair
   { name: 'Dolenza', emotion: 'despair' },
+  // Blank Prism - numbness
+  { name: 'Sedra', emotion: 'numbness' },
+  // Sapphire Chamber - grief
+  { name: 'Trosta', emotion: 'grief' },
+  // Empty House - isolation
   { name: 'Estrana', emotion: 'isolation' },
 ]

--- a/src/data/planets/mist.ts
+++ b/src/data/planets/mist.ts
@@ -1,9 +1,14 @@
 import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
-  { name: 'Obsceris', emotion: 'confusion' },
-  { name: 'Dysira', emotion: 'doubt' },
-  { name: 'Verio', emotion: 'curiosity' },
+  // Lucid Thread - curious
+  { name: 'Verio', emotion: 'curious' },
+  // Ancient Quiet - awe
   { name: 'Zonder', emotion: 'awe' },
+  // Fractal Maze - confusion
+  { name: 'Obsceris', emotion: 'confusion' },
+  // Shallow Anchor - doubt
+  { name: 'Dysira', emotion: 'doubt' },
+  // Myriad Glitch - surreal
   { name: 'Umbranova', emotion: 'surreal' },
 ]

--- a/src/data/planets/oasis.ts
+++ b/src/data/planets/oasis.ts
@@ -1,11 +1,18 @@
 import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
-  { name: 'Allora', emotion: 'belonging' },
-  { name: 'Lubovu', emotion: 'love' },
-  { name: 'Navari', emotion: 'peace' },
+  // Verdant Hearth - safe
   { name: 'Merulo', emotion: 'safe' },
+  // Radiant Grove - joy
   { name: 'Solene', emotion: 'joy' },
-  { name: 'Vivaly', emotion: 'playful' },
+  // Honey Bloom - love
+  { name: 'Lubovu', emotion: 'love' },
+  // Open Palm - grateful
   { name: 'Gawyn', emotion: 'grateful' },
+  // Woven Circle - belonging
+  { name: 'Allora', emotion: 'belonging' },
+  // Twinkle Toe - playful
+  { name: 'Vivaly', emotion: 'playful' },
+  // Soft Meadow - peace
+  { name: 'Navari', emotion: 'peace' },
 ]

--- a/src/data/planets/trace.ts
+++ b/src/data/planets/trace.ts
@@ -1,8 +1,12 @@
 import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
+  // Sepia Garden - nostalgia
   { name: 'Yorell', emotion: 'nostalgia' },
+  // Word Cemetery - regret
   { name: 'Renmor', emotion: 'regret' },
+  // Aurora Shadow - yearning
   { name: 'Fenric', emotion: 'yearning' },
+  // Butterfly Canopy - daydreaming
   { name: 'Drisano', emotion: 'daydreaming' },
 ]

--- a/src/data/planets/zenith.ts
+++ b/src/data/planets/zenith.ts
@@ -1,8 +1,12 @@
 import { CorePlanet } from '../types'
 
 export const corePlanets: CorePlanet[] = [
-  { name: 'Kalyra', emotion: 'empowerment' },
-  { name: 'Eladon', emotion: 'pride' },
-  { name: 'Zepharel', emotion: 'liberation' },
+  // Steadfast Anvil - endurance
   { name: 'Milenios', emotion: 'endurance' },
+  // Primordial Pillar - pride
+  { name: 'Eladon', emotion: 'pride' },
+  // Luminescent Crown - empowered
+  { name: 'Kalyra', emotion: 'empowered' },
+  // Omega Threshold - liberation
+  { name: 'Zepharel', emotion: 'liberation' },
 ]

--- a/src/data/realmData.ts
+++ b/src/data/realmData.ts
@@ -1,0 +1,45 @@
+import { realms } from './realmMetadata'
+import { EmotionCluster, CorePlanet, RealmDetail } from './types'
+
+import { clusters as abyssClusters } from './clusters/abyss'
+import { corePlanets as abyssPlanets } from './planets/abyss'
+
+import { clusters as cavernClusters } from './clusters/cavern'
+import { corePlanets as cavernPlanets } from './planets/cavern'
+
+import { clusters as drossClusters } from './clusters/dross'
+import { corePlanets as drossPlanets } from './planets/dross'
+
+import { clusters as emberClusters } from './clusters/ember'
+import { corePlanets as emberPlanets } from './planets/ember'
+
+import { clusters as glareClusters } from './clusters/glare'
+import { corePlanets as glarePlanets } from './planets/glare'
+
+import { clusters as languishClusters } from './clusters/languish'
+import { corePlanets as languishPlanets } from './planets/languish'
+
+import { clusters as mistClusters } from './clusters/mist'
+import { corePlanets as mistPlanets } from './planets/mist'
+
+import { clusters as oasisClusters } from './clusters/oasis'
+import { corePlanets as oasisPlanets } from './planets/oasis'
+
+import { clusters as traceClusters } from './clusters/trace'
+import { corePlanets as tracePlanets } from './planets/trace'
+
+import { clusters as zenithClusters } from './clusters/zenith'
+import { corePlanets as zenithPlanets } from './planets/zenith'
+
+export const realmData: Record<keyof typeof realms, RealmDetail> = {
+  abyss: { clusters: abyssClusters, corePlanets: abyssPlanets },
+  cavern: { clusters: cavernClusters, corePlanets: cavernPlanets },
+  dross: { clusters: drossClusters, corePlanets: drossPlanets },
+  ember: { clusters: emberClusters, corePlanets: emberPlanets },
+  glare: { clusters: glareClusters, corePlanets: glarePlanets },
+  languish: { clusters: languishClusters, corePlanets: languishPlanets },
+  mist: { clusters: mistClusters, corePlanets: mistPlanets },
+  oasis: { clusters: oasisClusters, corePlanets: oasisPlanets },
+  trace: { clusters: traceClusters, corePlanets: tracePlanets },
+  zenith: { clusters: zenithClusters, corePlanets: zenithPlanets },
+}

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -8,3 +8,8 @@ export interface CorePlanet {
   emotion: string
   satellites?: string[]
 }
+
+export interface RealmDetail {
+  clusters: EmotionCluster[]
+  corePlanets: CorePlanet[]
+}

--- a/src/pages/realms/createRealmPage.tsx
+++ b/src/pages/realms/createRealmPage.tsx
@@ -1,36 +1,13 @@
 import React from 'react'
 import RealmTemplate from '../../components/RealmTemplate'
 import { realms } from '../../data/realmMetadata'
-import { CorePlanet } from '../../data/types'
-import { corePlanets as abyssPlanets } from '../../data/planets/abyss'
-import { corePlanets as cavernPlanets } from '../../data/planets/cavern'
-import { corePlanets as drossPlanets } from '../../data/planets/dross'
-import { corePlanets as emberPlanets } from '../../data/planets/ember'
-import { corePlanets as glarePlanets } from '../../data/planets/glare'
-import { corePlanets as languishPlanets } from '../../data/planets/languish'
-import { corePlanets as mistPlanets } from '../../data/planets/mist'
-import { corePlanets as oasisPlanets } from '../../data/planets/oasis'
-import { corePlanets as tracePlanets } from '../../data/planets/trace'
-import { corePlanets as zenithPlanets } from '../../data/planets/zenith'
+import { realmData } from '../../data/realmData'
 
 const createRealmPage =
   (realmKey: keyof typeof realms): React.FC =>
   () => {
     const realm = realms[realmKey]
-    const planetMap: Record<keyof typeof realms, CorePlanet[]> = {
-      abyss: abyssPlanets,
-      cavern: cavernPlanets,
-      dross: drossPlanets,
-      ember: emberPlanets,
-      glare: glarePlanets,
-      languish: languishPlanets,
-      mist: mistPlanets,
-      oasis: oasisPlanets,
-      trace: tracePlanets,
-      zenith: zenithPlanets,
-    }
-
-    const corePlanets = planetMap[realmKey]
+    const { corePlanets } = realmData[realmKey]
 
     return <RealmTemplate realmName={realm.realmName} corePlanets={corePlanets} />
   }


### PR DESCRIPTION
## Summary
- connect cluster and planet data into a single `realmData` map
- reorder each realm's `corePlanets` so the first emotion matches its cluster's core emotion
- tweak several planet emotions for exact alignment
- update realm page creation to pull planets from the new unified data map
- expand shared data types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684de4441b448325bd62a2d68c253c78