### PR TITLE
Refactor realm data loading

### DIFF
--- a/src/data/realmData.ts
+++ b/src/data/realmData.ts
@@ -1,45 +1,28 @@
 import { realms } from './realmMetadata'
-import { EmotionCluster, CorePlanet, RealmDetail } from './types'
+import { RealmDetail } from './types'
 
-import { clusters as abyssClusters } from './clusters/abyss'
-import { corePlanets as abyssPlanets } from './planets/abyss'
+/**
+ * Dynamically load detailed data for a single realm.
+ */
+export async function loadRealmDetail(
+  realmKey: keyof typeof realms,
+): Promise<RealmDetail> {
+  const mod = await import(`./realms/${realmKey}`)
+  return { clusters: mod.clusters, corePlanets: mod.corePlanets }
+}
 
-import { clusters as cavernClusters } from './clusters/cavern'
-import { corePlanets as cavernPlanets } from './planets/cavern'
-
-import { clusters as drossClusters } from './clusters/dross'
-import { corePlanets as drossPlanets } from './planets/dross'
-
-import { clusters as emberClusters } from './clusters/ember'
-import { corePlanets as emberPlanets } from './planets/ember'
-
-import { clusters as glareClusters } from './clusters/glare'
-import { corePlanets as glarePlanets } from './planets/glare'
-
-import { clusters as languishClusters } from './clusters/languish'
-import { corePlanets as languishPlanets } from './planets/languish'
-
-import { clusters as mistClusters } from './clusters/mist'
-import { corePlanets as mistPlanets } from './planets/mist'
-
-import { clusters as oasisClusters } from './clusters/oasis'
-import { corePlanets as oasisPlanets } from './planets/oasis'
-
-import { clusters as traceClusters } from './clusters/trace'
-import { corePlanets as tracePlanets } from './planets/trace'
-
-import { clusters as zenithClusters } from './clusters/zenith'
-import { corePlanets as zenithPlanets } from './planets/zenith'
-
-export const realmData: Record<keyof typeof realms, RealmDetail> = {
-  abyss: { clusters: abyssClusters, corePlanets: abyssPlanets },
-  cavern: { clusters: cavernClusters, corePlanets: cavernPlanets },
-  dross: { clusters: drossClusters, corePlanets: drossPlanets },
-  ember: { clusters: emberClusters, corePlanets: emberPlanets },
-  glare: { clusters: glareClusters, corePlanets: glarePlanets },
-  languish: { clusters: languishClusters, corePlanets: languishPlanets },
-  mist: { clusters: mistClusters, corePlanets: mistPlanets },
-  oasis: { clusters: oasisClusters, corePlanets: oasisPlanets },
-  trace: { clusters: traceClusters, corePlanets: tracePlanets },
-  zenith: { clusters: zenithClusters, corePlanets: zenithPlanets },
+/**
+ * Load data for all realms at once. Results are cached after first call.
+ */
+let cached: Record<keyof typeof realms, RealmDetail> | null = null
+export async function getAllRealmData(): Promise<Record<keyof typeof realms, RealmDetail>> {
+  if (cached) return cached
+  const entries = await Promise.all(
+    (Object.keys(realms) as (keyof typeof realms)[]).map(async key => [
+      key,
+      await loadRealmDetail(key),
+    ] as const),
+  )
+  cached = Object.fromEntries(entries) as Record<keyof typeof realms, RealmDetail>
+  return cached
 }

--- a/src/data/realms/abyss.ts
+++ b/src/data/realms/abyss.ts
@@ -1,0 +1,15 @@
+import { clusters as clusterData } from '../clusters/abyss'
+import { corePlanets as planetData } from '../planets/abyss'
+import { realms } from '../realmMetadata'
+import { Realm } from '../types'
+
+export const clusters = clusterData
+export const corePlanets = planetData
+
+const realm: Realm = {
+  realmName: realms['abyss'].realmName,
+  clusters,
+  corePlanets,
+}
+
+export default realm

--- a/src/data/realms/cavern.ts
+++ b/src/data/realms/cavern.ts
@@ -1,0 +1,15 @@
+import { clusters as clusterData } from '../clusters/cavern'
+import { corePlanets as planetData } from '../planets/cavern'
+import { realms } from '../realmMetadata'
+import { Realm } from '../types'
+
+export const clusters = clusterData
+export const corePlanets = planetData
+
+const realm: Realm = {
+  realmName: realms['cavern'].realmName,
+  clusters,
+  corePlanets,
+}
+
+export default realm

--- a/src/data/realms/dross.ts
+++ b/src/data/realms/dross.ts
@@ -1,0 +1,15 @@
+import { clusters as clusterData } from '../clusters/dross'
+import { corePlanets as planetData } from '../planets/dross'
+import { realms } from '../realmMetadata'
+import { Realm } from '../types'
+
+export const clusters = clusterData
+export const corePlanets = planetData
+
+const realm: Realm = {
+  realmName: realms['dross'].realmName,
+  clusters,
+  corePlanets,
+}
+
+export default realm

--- a/src/data/realms/ember.ts
+++ b/src/data/realms/ember.ts
@@ -1,0 +1,15 @@
+import { clusters as clusterData } from '../clusters/ember'
+import { corePlanets as planetData } from '../planets/ember'
+import { realms } from '../realmMetadata'
+import { Realm } from '../types'
+
+export const clusters = clusterData
+export const corePlanets = planetData
+
+const realm: Realm = {
+  realmName: realms['ember'].realmName,
+  clusters,
+  corePlanets,
+}
+
+export default realm

--- a/src/data/realms/glare.ts
+++ b/src/data/realms/glare.ts
@@ -1,0 +1,15 @@
+import { clusters as clusterData } from '../clusters/glare'
+import { corePlanets as planetData } from '../planets/glare'
+import { realms } from '../realmMetadata'
+import { Realm } from '../types'
+
+export const clusters = clusterData
+export const corePlanets = planetData
+
+const realm: Realm = {
+  realmName: realms['glare'].realmName,
+  clusters,
+  corePlanets,
+}
+
+export default realm

--- a/src/data/realms/languish.ts
+++ b/src/data/realms/languish.ts
@@ -1,0 +1,15 @@
+import { clusters as clusterData } from '../clusters/languish'
+import { corePlanets as planetData } from '../planets/languish'
+import { realms } from '../realmMetadata'
+import { Realm } from '../types'
+
+export const clusters = clusterData
+export const corePlanets = planetData
+
+const realm: Realm = {
+  realmName: realms['languish'].realmName,
+  clusters,
+  corePlanets,
+}
+
+export default realm

--- a/src/data/realms/mist.ts
+++ b/src/data/realms/mist.ts
@@ -1,0 +1,15 @@
+import { clusters as clusterData } from '../clusters/mist'
+import { corePlanets as planetData } from '../planets/mist'
+import { realms } from '../realmMetadata'
+import { Realm } from '../types'
+
+export const clusters = clusterData
+export const corePlanets = planetData
+
+const realm: Realm = {
+  realmName: realms['mist'].realmName,
+  clusters,
+  corePlanets,
+}
+
+export default realm

--- a/src/data/realms/oasis.ts
+++ b/src/data/realms/oasis.ts
@@ -1,0 +1,15 @@
+import { clusters as clusterData } from '../clusters/oasis'
+import { corePlanets as planetData } from '../planets/oasis'
+import { realms } from '../realmMetadata'
+import { Realm } from '../types'
+
+export const clusters = clusterData
+export const corePlanets = planetData
+
+const realm: Realm = {
+  realmName: realms['oasis'].realmName,
+  clusters,
+  corePlanets,
+}
+
+export default realm

--- a/src/data/realms/trace.ts
+++ b/src/data/realms/trace.ts
@@ -1,0 +1,15 @@
+import { clusters as clusterData } from '../clusters/trace'
+import { corePlanets as planetData } from '../planets/trace'
+import { realms } from '../realmMetadata'
+import { Realm } from '../types'
+
+export const clusters = clusterData
+export const corePlanets = planetData
+
+const realm: Realm = {
+  realmName: realms['trace'].realmName,
+  clusters,
+  corePlanets,
+}
+
+export default realm

--- a/src/data/realms/zenith.ts
+++ b/src/data/realms/zenith.ts
@@ -1,0 +1,15 @@
+import { clusters as clusterData } from '../clusters/zenith'
+import { corePlanets as planetData } from '../planets/zenith'
+import { realms } from '../realmMetadata'
+import { Realm } from '../types'
+
+export const clusters = clusterData
+export const corePlanets = planetData
+
+const realm: Realm = {
+  realmName: realms['zenith'].realmName,
+  clusters,
+  corePlanets,
+}
+
+export default realm

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -13,3 +13,10 @@ export interface RealmDetail {
   clusters: EmotionCluster[]
   corePlanets: CorePlanet[]
 }
+
+import type { RealmMeta } from './realmMetadata'
+
+/**
+ * Full data for a realm including its meta information.
+ */
+export interface Realm extends RealmMeta, RealmDetail {}

--- a/src/data/validateRealms.ts
+++ b/src/data/validateRealms.ts
@@ -1,0 +1,36 @@
+import { realms } from './realmMetadata'
+import { loadRealmDetail } from './realmData'
+
+async function validate() {
+  let ok = true
+  for (const key of Object.keys(realms) as (keyof typeof realms)[]) {
+    const detail = await loadRealmDetail(key)
+    if (!detail.clusters.length) {
+      console.error(`${key} has no clusters`)
+      ok = false
+    }
+    if (!detail.corePlanets.length) {
+      console.error(`${key} has no core planets`)
+      ok = false
+    }
+    const emotions = detail.clusters.flatMap(c => c.emotions)
+    for (const planet of detail.corePlanets) {
+      if (!emotions.includes(planet.emotion)) {
+        console.error(
+          `${planet.name} emotion '${planet.emotion}' not found in clusters for ${key}`,
+        )
+        ok = false
+      }
+    }
+  }
+  if (ok) {
+    console.log('All realm data validated.')
+  } else {
+    process.exitCode = 1
+  }
+}
+
+validate().catch(err => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/src/pages/realms/createRealmPage.tsx
+++ b/src/pages/realms/createRealmPage.tsx
@@ -1,15 +1,19 @@
 import React from 'react'
 import RealmTemplate from '../../components/RealmTemplate'
 import { realms } from '../../data/realmMetadata'
-import { realmData } from '../../data/realmData'
+import { loadRealmDetail } from '../../data/realmData'
+import { useEffect, useState } from 'react'
+import type { CorePlanet } from '../../data/types'
 
-const createRealmPage =
-  (realmKey: keyof typeof realms): React.FC =>
-  () => {
-    const realm = realms[realmKey]
-    const { corePlanets } = realmData[realmKey]
+const createRealmPage = (realmKey: keyof typeof realms): React.FC => () => {
+  const realm = realms[realmKey]
+  const [corePlanets, setPlanets] = useState<CorePlanet[]>([])
 
-    return <RealmTemplate realmName={realm.realmName} corePlanets={corePlanets} />
-  }
+  useEffect(() => {
+    loadRealmDetail(realmKey).then(detail => setPlanets(detail.corePlanets))
+  }, [])
+
+  return <RealmTemplate realmName={realm.realmName} corePlanets={corePlanets} />
+}
 
 export default createRealmPage


### PR DESCRIPTION
## Summary
- consolidate cluster and planet data into single realm modules
- dynamically load realm data when needed
- extend types to include new `Realm` interface
- enable dynamic loading in realm pages
- provide a validator script for realm data integrity

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'react' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684de63b540c83258dc24c207e1ad520