### PR TITLE
Improve navigation accessibility & reuse

### DIFF
--- a/client/pages/abyss.html
+++ b/client/pages/abyss.html
@@ -13,13 +13,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <main>
       <section id="realm-space" class="realm-section">
         <div class="realm-icon">🕳️</div>
@@ -28,5 +22,6 @@
       </section>
     </main>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
   </body>
 </html>

--- a/client/pages/cavern.html
+++ b/client/pages/cavern.html
@@ -13,13 +13,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <main>
       <section id="realm-space" class="realm-section">
         <div class="realm-icon">🪨</div>
@@ -28,5 +22,6 @@
       </section>
     </main>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
   </body>
 </html>

--- a/client/pages/dross.html
+++ b/client/pages/dross.html
@@ -13,13 +13,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <main>
       <section id="realm-space" class="realm-section">
         <div class="realm-icon">☣️</div>
@@ -28,5 +22,6 @@
       </section>
     </main>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
   </body>
 </html>

--- a/client/pages/ember.html
+++ b/client/pages/ember.html
@@ -13,13 +13,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <main>
       <section id="realm-space" class="realm-section">
         <div class="realm-icon">🔥</div>
@@ -28,5 +22,6 @@
       </section>
     </main>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
   </body>
 </html>

--- a/client/pages/glare.html
+++ b/client/pages/glare.html
@@ -13,13 +13,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <main>
       <section id="realm-space" class="realm-section">
         <div class="realm-icon">👁️</div>
@@ -28,5 +22,6 @@
       </section>
     </main>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
   </body>
 </html>

--- a/client/pages/home.html
+++ b/client/pages/home.html
@@ -15,13 +15,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <main id="home-main">
       <div id="left-column">
         <section id="profile-section" class="home-section">
@@ -89,6 +83,7 @@
       </section>
     </main>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
     <script src="../scripts/checkin.js"></script>
   </body>
 </html>

--- a/client/pages/languish.html
+++ b/client/pages/languish.html
@@ -13,13 +13,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <main>
       <section id="realm-space" class="realm-section">
         <div class="realm-icon">💧</div>
@@ -28,5 +22,6 @@
       </section>
     </main>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
   </body>
 </html>

--- a/client/pages/mist.html
+++ b/client/pages/mist.html
@@ -13,13 +13,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <main>
       <section id="realm-space" class="realm-section">
         <div class="realm-icon">🌫️</div>
@@ -28,5 +22,6 @@
       </section>
     </main>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
   </body>
 </html>

--- a/client/pages/oasis.html
+++ b/client/pages/oasis.html
@@ -13,13 +13,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <main>
       <section id="realm-space" class="realm-section">
         <div class="realm-icon">🌴</div>
@@ -28,5 +22,6 @@
       </section>
     </main>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
   </body>
 </html>

--- a/client/pages/profile.html
+++ b/client/pages/profile.html
@@ -14,13 +14,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <main id="profile-main">
       <section id="profile-overview" class="home-section">
         <h2>Your Cosmic Profile</h2>
@@ -28,5 +22,6 @@
       </section>
     </main>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
   </body>
 </html>

--- a/client/pages/trace.html
+++ b/client/pages/trace.html
@@ -13,13 +13,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <main>
       <section id="realm-space" class="realm-section">
         <div class="realm-icon">🌀</div>
@@ -28,5 +22,6 @@
       </section>
     </main>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
   </body>
 </html>

--- a/client/pages/universe.html
+++ b/client/pages/universe.html
@@ -15,13 +15,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <div id="universe">
       <div id="space">
         <div class="planet" id="abyss">Abyss</div>
@@ -47,6 +41,7 @@
       <div id="realm-overlay" class="hidden" aria-live="polite"></div>
     </div>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
     <script src="../scripts/universe.js"></script>
   </body>
 </html>

--- a/client/pages/zenith.html
+++ b/client/pages/zenith.html
@@ -13,13 +13,7 @@
       <div class="nebula" id="nebula2"></div>
     </div>
     <div id="stars"></div>
-    <nav id="main-nav" aria-label="primary">
-      <ul>
-        <li><a href="home.html">Home</a></li>
-        <li><a href="profile.html">Profile</a></li>
-        <li><a href="universe.html">Universe</a></li>
-      </ul>
-    </nav>
+    <nav id="main-nav" aria-label="primary"></nav>
     <main>
       <section id="realm-space" class="realm-section">
         <div class="realm-icon">🚀</div>
@@ -28,5 +22,6 @@
       </section>
     </main>
     <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
   </body>
 </html>

--- a/client/partials/nav.html
+++ b/client/partials/nav.html
@@ -1,0 +1,7 @@
+<nav aria-label="primary">
+  <ul>
+    <li><a href="home.html">Home</a></li>
+    <li><a href="profile.html">Profile</a></li>
+    <li><a href="universe.html">Universe</a></li>
+  </ul>
+</nav>

--- a/client/scripts/nav.js
+++ b/client/scripts/nav.js
@@ -1,0 +1,23 @@
+// Loads the shared navigation and highlights the active page
+
+document.addEventListener('DOMContentLoaded', () => {
+  const nav = document.getElementById('main-nav')
+  if (!nav) return
+
+  fetch('../partials/nav.html')
+    .then(res => res.text())
+    .then(html => {
+      nav.innerHTML = html
+      markCurrentPage()
+    })
+    .catch(err => console.error('Navigation failed to load', err))
+
+  function markCurrentPage() {
+    const page = window.location.pathname.split('/').pop()
+    nav.querySelectorAll('a[href]').forEach(link => {
+      if (link.getAttribute('href') === page) {
+        link.setAttribute('aria-current', 'page')
+      }
+    })
+  }
+})

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -147,11 +147,29 @@ h1 {
   transition: background 0.3s ease, box-shadow 0.3s ease;
 }
 
-#main-nav a:hover,
+#main-nav a:hover {
+  background: rgba(255, 255, 255, 0.25);
+  box-shadow: 0 0 12px rgba(255, 20, 147, 0.6);
+}
+
 #main-nav a:focus {
   background: rgba(255, 255, 255, 0.25);
   box-shadow: 0 0 12px rgba(255, 20, 147, 0.6);
-  outline: none;
+  outline: 2px dashed #fff;
+  outline-offset: 4px;
+}
+
+#main-nav a[aria-current='page'] {
+  background: rgba(255, 255, 255, 0.35);
+  box-shadow: 0 0 12px rgba(173, 216, 230, 0.7);
+}
+
+@media (max-width: 600px) {
+  #main-nav ul {
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+  }
 }
 
 @keyframes headerGradient {


### PR DESCRIPTION
## Summary
- centralize navigation markup in `/client/partials/nav.html`
- load navigation via new script and highlight current page
- adjust navigation styles for focus/active states
- add simple mobile layout
- update every page to use the shared navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e6c3ed3dc8325bdef288b5699bc2a