### PR TITLE
Harden static file server

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -81,6 +81,9 @@ async function run() {
       'universe.js should have application/javascript content-type'
     );
 
+    const traversal = await fetch('/../server/server.js');
+    assert.strictEqual(traversal.statusCode, 404, 'traversal attempt should return 404');
+
     console.log('All tests passed.');
   } finally {
     heart.kill();


### PR DESCRIPTION
## Summary
- secure static file serving by verifying normalized paths stay inside `client/`
- stream files to responses instead of reading the entire file first
- return 404 when path traversal is attempted
- test for traversal request `../server/server.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ea40f1d2083259251fc2a8e27b8bc