### PR TITLE
Add explore page with realm suggestion form

### DIFF
--- a/client/pages/explore.html
+++ b/client/pages/explore.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Elysium - Explore</title>
+    <link rel="stylesheet" href="../styles/style.css" />
+    <link rel="stylesheet" href="../styles/home.css" />
+  </head>
+  <body>
+    <div id="fadeOverlay"></div>
+    <div id="nebula-container">
+      <div class="nebula" id="nebula1"></div>
+      <div class="nebula" id="nebula2"></div>
+    </div>
+    <div id="stars"></div>
+    <nav id="main-nav" aria-label="primary"></nav>
+    <main id="explore-main">
+      <section id="explore-section" class="home-section">
+        <h2 class="stellar-heading">Choose Your Path</h2>
+        <form id="explore-form" class="form" aria-describedby="explore-desc">
+          <p id="explore-desc" class="visually-hidden">
+            Answer these prompts to reveal a realm aligned with your heart.
+          </p>
+          <label for="e1">Energy for adventure</label>
+          <select id="e1" name="e1">
+            <option value="1">1 - Faint</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5 - Boundless</option>
+          </select>
+          <label for="e2">Drawn to light or shadow</label>
+          <select id="e2" name="e2">
+            <option value="1">1 - Deep Shadow</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5 - Brilliant Light</option>
+          </select>
+          <label for="e3">Need for connection</label>
+          <select id="e3" name="e3">
+            <option value="1">1 - Solitary</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5 - Seeking Community</option>
+          </select>
+          <button type="submit" class="submit-btn">Show Realm</button>
+        </form>
+        <div id="explore-result" class="hidden" aria-live="polite"></div>
+      </section>
+    </main>
+    <script src="../scripts/background.js"></script>
+    <script src="../scripts/nav.js"></script>
+    <script src="../scripts/explore.js"></script>
+  </body>
+</html>

--- a/client/partials/nav.html
+++ b/client/partials/nav.html
@@ -6,6 +6,7 @@
   <ul>
     <li><a href="home.html">Home</a></li>
     <li><a href="profile.html">Profile</a></li>
+    <li><a href="explore.html">Explore</a></li>
     <li><a href="universe.html">Universe</a></li>
   </ul>
 </nav>

--- a/client/scripts/explore.js
+++ b/client/scripts/explore.js
@@ -1,0 +1,50 @@
+// Selects a realm based on the visitor's responses
+// Uses names from src/data/realmMetadata.ts
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('explore-form');
+  const result = document.getElementById('explore-result');
+  if (!form || !result) return;
+
+  // realm names from src/data/realmMetadata.ts
+  const realms = {
+    abyss: { realmName: 'Abyss' },
+    cavern: { realmName: 'Cavern' },
+    dross: { realmName: 'Dross' },
+    ember: { realmName: 'Ember' },
+    glare: { realmName: 'Glare' },
+    languish: { realmName: 'Languish' },
+    mist: { realmName: 'Mist' },
+    oasis: { realmName: 'Oasis' },
+    trace: { realmName: 'Trace' },
+    zenith: { realmName: 'Zenith' },
+  };
+
+  const keys = Object.keys(realms);
+  const step = 4 / keys.length; // map range 1-5 onto realm indices
+
+  function escapeHTML(str) {
+    const map = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+    };
+    return str.replace(/[&<>"']/g, m => map[m]);
+  }
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const values = Array.from(form.querySelectorAll('select')).map(sel =>
+      parseInt(sel.value, 10),
+    );
+    const avg = values.reduce((a, b) => a + b, 0) / values.length;
+    const index = Math.min(keys.length - 1, Math.floor((avg - 1) / step));
+    const key = keys[index];
+    const name = escapeHTML(realms[key].realmName);
+    result.innerHTML = `You feel the pull of <strong>${name}</strong>.`;
+    result.classList.remove('hidden');
+    form.classList.add('hidden');
+  });
+});


### PR DESCRIPTION
## Summary
- add Explore page for simple mood-based prompts
- create explore.js to choose realms using `realmMetadata`
- link Explore in site navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684faa63f1588325ab7a0bcfaa08c464