### PR TITLE
Fix tests to catch TS compile errors

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -26,11 +26,22 @@ function fetch(pathname) {
 
 async function run() {
   // compile TypeScript sources for tests
-  spawnSync('npx', ['tsc', '--module', 'commonjs', '--outDir', 'build_test'], {
-    stdio: 'inherit',
-  })
+  const compile = spawnSync(
+    'npx',
+    ['tsc', '--module', 'commonjs', '--outDir', 'build_test'],
+    {
+      stdio: 'inherit',
+    },
+  )
+  if (compile.status !== 0) {
+    throw new Error('TypeScript compilation failed')
+  }
+
   // run the full build and ensure output exists
-  spawnSync('npm', ['run', 'build'], { stdio: 'inherit' })
+  const build = spawnSync('npm', ['run', 'build'], { stdio: 'inherit' })
+  if (build.status !== 0) {
+    throw new Error('npm run build failed')
+  }
   const buildOutput = path.join(__dirname, '..', 'build', 'data', 'realmData.js')
   assert.ok(fs.existsSync(buildOutput), 'build should create compiled files')
   const serverPath = path.join(__dirname, '..', 'server', 'server.js');


### PR DESCRIPTION
## Summary
- ensure automated tests fail when TypeScript compilation fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d968f7448325b1751a40a17fd72e