### PR TITLE
Add full realm quiz

### DIFF
--- a/client/pages/explore.html
+++ b/client/pages/explore.html
@@ -20,34 +20,40 @@
         <h2 class="stellar-heading">Choose Your Path</h2>
         <form id="explore-form" class="form" aria-describedby="explore-desc">
           <p id="explore-desc" class="visually-hidden">
-            Answer these prompts to reveal a realm aligned with your heart.
+            Select the realm that calls to you in this moment.
           </p>
-          <label for="e1">Energy for adventure</label>
-          <select id="e1" name="e1">
-            <option value="1">1 - Faint</option>
-            <option value="2">2</option>
-            <option value="3">3</option>
-            <option value="4">4</option>
-            <option value="5">5 - Boundless</option>
-          </select>
-          <label for="e2">Drawn to light or shadow</label>
-          <select id="e2" name="e2">
-            <option value="1">1 - Deep Shadow</option>
-            <option value="2">2</option>
-            <option value="3">3</option>
-            <option value="4">4</option>
-            <option value="5">5 - Brilliant Light</option>
-          </select>
-          <label for="e3">Need for connection</label>
-          <select id="e3" name="e3">
-            <option value="1">1 - Solitary</option>
-            <option value="2">2</option>
-            <option value="3">3</option>
-            <option value="4">4</option>
-            <option value="5">5 - Seeking Community</option>
-          </select>
-          <button type="submit" class="submit-btn">Show Realm</button>
+          <fieldset>
+            <legend class="visually-hidden">Realm options</legend>
+            <div class="realm-options">
+              <label><input type="radio" name="realm" value="abyss" required /> Abyss</label>
+              <label><input type="radio" name="realm" value="cavern" /> Cavern</label>
+              <label><input type="radio" name="realm" value="dross" /> Dross</label>
+              <label><input type="radio" name="realm" value="ember" /> Ember</label>
+              <label><input type="radio" name="realm" value="glare" /> Glare</label>
+              <label><input type="radio" name="realm" value="languish" /> Languish</label>
+              <label><input type="radio" name="realm" value="mist" /> Mist</label>
+              <label><input type="radio" name="realm" value="oasis" /> Oasis</label>
+              <label><input type="radio" name="realm" value="trace" /> Trace</label>
+              <label><input type="radio" name="realm" value="zenith" /> Zenith</label>
+            </div>
+          </fieldset>
+          <button type="submit" class="submit-btn">Reveal Realm</button>
         </form>
+        <details id="answer-key">
+          <summary>Answer Key</summary>
+          <ol>
+            <li>Abyss</li>
+            <li>Cavern</li>
+            <li>Dross</li>
+            <li>Ember</li>
+            <li>Glare</li>
+            <li>Languish</li>
+            <li>Mist</li>
+            <li>Oasis</li>
+            <li>Trace</li>
+            <li>Zenith</li>
+          </ol>
+        </details>
         <div id="explore-result" class="hidden" aria-live="polite"></div>
       </section>
     </main>

--- a/client/scripts/explore.js
+++ b/client/scripts/explore.js
@@ -20,8 +20,6 @@ document.addEventListener('DOMContentLoaded', () => {
     zenith: { realmName: 'Zenith' },
   };
 
-  const keys = Object.keys(realms);
-  const step = 4 / keys.length; // map range 1-5 onto realm indices
 
   function escapeHTML(str) {
     const map = {
@@ -36,13 +34,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   form.addEventListener('submit', e => {
     e.preventDefault();
-    const values = Array.from(form.querySelectorAll('select')).map(sel =>
-      parseInt(sel.value, 10),
-    );
-    const avg = values.reduce((a, b) => a + b, 0) / values.length;
-    const index = Math.min(keys.length - 1, Math.floor((avg - 1) / step));
-    const key = keys[index];
-    const name = escapeHTML(realms[key].realmName);
+    const chosen = form.querySelector('input[name="realm"]:checked');
+    if (!chosen) return;
+    const key = chosen.value;
+    const name = escapeHTML(realms[key]?.realmName || key);
     result.innerHTML = `You feel the pull of <strong>${name}</strong>.`;
     result.classList.remove('hidden');
     form.classList.add('hidden');


### PR DESCRIPTION
## Summary
- rework explore page survey into a single radio-based quiz
- show all ten realm names in a new answer key
- simplify explore.js logic to read selected realm

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68511167cb688325afad56b8ec9e3ca7