### PR TITLE
Fix duplicate class attribute on fade overlay

### DIFF
--- a/client/pages/about.html
+++ b/client/pages/about.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
   <body>
-    <div id="fadeOverlay" class="start" class="start"></div>
+    <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>
       <div class="nebula" id="nebula2"></div>

--- a/client/pages/explore.html
+++ b/client/pages/explore.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="../styles/home.css" />
   </head>
   <body>
-    <div id="fadeOverlay" class="start" class="start"></div>
+    <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>
       <div class="nebula" id="nebula2"></div>

--- a/client/pages/home.html
+++ b/client/pages/home.html
@@ -9,7 +9,7 @@
   </head>
 
   <body>
-    <div id="fadeOverlay" class="start" class="start"></div>
+    <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>
       <div class="nebula" id="nebula2"></div>


### PR DESCRIPTION
## Summary
- remove redundant `class="start"` from `fadeOverlay` div in various pages

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68561c3dd8fc83258bbd68f433eee51e