### PR TITLE
Add descriptions to HTML pages

### DIFF
--- a/client/pages/about.html
+++ b/client/pages/about.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Reflections on the philosophy guiding the Elysium cosmos."
+    />
     <title>Elysium Philosophy</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>

--- a/client/pages/abyss.html
+++ b/client/pages/abyss.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Sink into the shadowed depths of Elysium's Abyss Realm."
+    />
     <title>Abyss Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>

--- a/client/pages/cavern.html
+++ b/client/pages/cavern.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Wander through the echoing quiet of the Cavern Realm."
+    />
     <title>Cavern Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>

--- a/client/pages/dross.html
+++ b/client/pages/dross.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Explore the discarded truths inside the Dross Realm."
+    />
     <title>Dross Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>

--- a/client/pages/ember.html
+++ b/client/pages/ember.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Feel the lingering warmth and sparks of the Ember Realm."
+    />
     <title>Ember Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>

--- a/client/pages/explore.html
+++ b/client/pages/explore.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Find your path among feelings and stars in Elysium."
+    />
     <title>Elysium - Explore</title>
     <link rel="stylesheet" href="../styles/style.css" />
     <link rel="stylesheet" href="../styles/home.css" />

--- a/client/pages/glare.html
+++ b/client/pages/glare.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Confront the blinding brilliance of the Glare Realm."
+    />
     <title>Glare Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>

--- a/client/pages/home.html
+++ b/client/pages/home.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Your personal gateway to the celestial community of Elysium."
+    />
     <title>Elysium Web - Home</title>
     <link rel="stylesheet" href="../styles/style.css" />
     <link rel="stylesheet" href="../styles/home.css" />

--- a/client/pages/languish.html
+++ b/client/pages/languish.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Rest in the gentle stillness of the Languish Realm."
+    />
     <title>Languish Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>

--- a/client/pages/mist.html
+++ b/client/pages/mist.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Lose and find yourself within the Mist Realm's haze."
+    />
     <title>Mist Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>

--- a/client/pages/oasis.html
+++ b/client/pages/oasis.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Breathe in calm waters and hope of the Oasis Realm."
+    />
     <title>Oasis Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>

--- a/client/pages/profile.html
+++ b/client/pages/profile.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="See your reflections and journeys across Elysium."
+    />
     <title>Elysium Profile</title>
     <link rel="stylesheet" href="../styles/style.css" />
     <link rel="stylesheet" href="../styles/home.css" />

--- a/client/pages/trace.html
+++ b/client/pages/trace.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Follow faint memories across the mysterious Trace Realm."
+    />
     <title>Trace Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>

--- a/client/pages/universe.html
+++ b/client/pages/universe.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Navigate the full expanse of Elysium's cosmic universe."
+    />
     <title>Elysium Universe</title>
     <link rel="stylesheet" href="../styles/style.css" />
     <link rel="stylesheet" href="../styles/universe.css" />

--- a/client/pages/zenith.html
+++ b/client/pages/zenith.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Ascend toward the highest light of the Zenith Realm."
+    />
     <title>Zenith Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>


### PR DESCRIPTION
## Summary
- add meta descriptions to every page under `client/pages`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68561cbd4a748325924c28d562acf128