### PR TITLE
Add plain text header for 404 responses

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -17,13 +17,18 @@ const mimeTypes = {
   '.woff2': 'font/woff2',
 }
 
+// Gracefully send a plain 404 when the requested file slips through our fingers.
+function send404(res) {
+  res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+  res.end('Not found')
+}
+
 function serveFile(filePath, res) {
   const ext = path.extname(filePath).toLowerCase()
   const contentType = mimeTypes[ext] || 'application/octet-stream'
   const stream = fs.createReadStream(filePath)
   stream.on('error', () => {
-    res.writeHead(404)
-    res.end('Not found')
+    send404(res)
   })
   res.writeHead(200, { 'Content-Type': contentType })
   stream.pipe(res)
@@ -34,8 +39,7 @@ const server = http.createServer((req, res) => {
   let filePath = path.normalize(path.join(root, requestPath))
 
   if (!filePath.startsWith(root)) {
-    res.writeHead(404)
-    res.end('Not found')
+    send404(res)
     return
   }
 
@@ -45,8 +49,7 @@ const server = http.createServer((req, res) => {
 
   fs.stat(filePath, (err, stats) => {
     if (err) {
-      res.writeHead(404)
-      res.end('Not found')
+      send404(res)
       return
     }
     if (stats.isDirectory()) {


### PR DESCRIPTION
## Summary
- introduce `send404` helper in `server.js`
- return 404 responses with `Content-Type: text/plain; charset=utf-8`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856227bdb6483259ab1dd95ce0e6ac9