### PR TITLE
Generate overlay data during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ npm run build
 The compiled JavaScript will appear in `build/` using the configuration in
 `tsconfig.json`.
 Running this command also renders each realm page to static HTML in
-`client/pages/` using the latest data. If you edit any templates or realm
+`client/pages/` using the latest data and writes a small helper script
+`client/scripts/overlayData.js` so the universe page can read overlay
+descriptions without the TypeScript sources. If you edit any templates or realm
 details, run `npm run build` again to refresh the pages.
 
 ## Realm metadata

--- a/client/scripts/overlayData.js
+++ b/client/scripts/overlayData.js
@@ -1,6 +1,4 @@
-// Overlay data is now embedded directly so realm pages
-// work even when the TypeScript build output is absent.
-// This mirrors the structure in src/data/overlayData.ts
+// Generated from src/data/overlayData.ts
 export const overlayData = {
   abyss: {
     icon: '🕳️',
@@ -24,19 +22,38 @@ export const overlayData = {
   },
   dross: {
     icon: '☣️',
-    features: ['Putrid Force', 'Tarry Bone', 'Stolen Doll', 'Pale Shiver']
+    features: [
+      'Putrid Force',
+      'Tarry Bone',
+      'Stolen Doll',
+      'Pale Shiver'
+    ]
   },
   ember: {
     icon: '🔥',
-    features: ['Infernal Mammoth', 'Brazen Rhino', 'Noisy Wasp', 'Vicious Cobra']
+    features: [
+      'Infernal Mammoth',
+      'Brazen Rhino',
+      'Noisy Wasp',
+      'Vicious Cobra'
+    ]
   },
   glare: {
     icon: '👁️',
-    features: ['Fallen Eye', 'Deadlight Hall', 'Raucous Laugh']
+    features: [
+      'Fallen Eye',
+      'Deadlight Hall',
+      'Raucous Laugh'
+    ]
   },
   languish: {
     icon: '💧',
-    features: ['Glass Crypt', 'Blank Prism', 'Sapphire Chamber', 'Empty House']
+    features: [
+      'Glass Crypt',
+      'Blank Prism',
+      'Sapphire Chamber',
+      'Empty House'
+    ]
   },
   mist: {
     icon: '🌫️',
@@ -62,7 +79,12 @@ export const overlayData = {
   },
   trace: {
     icon: '🌀',
-    features: ['Sepia Garden', 'Word Cemetery', 'Aurora Shadow', 'Butterfly Canopy']
+    features: [
+      'Sepia Garden',
+      'Word Cemetery',
+      'Aurora Shadow',
+      'Butterfly Canopy'
+    ]
   },
   zenith: {
     icon: '🚀',
@@ -73,7 +95,6 @@ export const overlayData = {
       'Omega Threshold'
     ]
   }
-}
+};
 
-// expose globally for universe.js to consume
 window.overlayData = overlayData;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server/server.js",
     "test": "node test/test.js",
     "format": "prettier --write \"client/**/*.{js,css,html}\" \"server/**/*.js\" \"test/**/*.js\" \"src/**/*.{ts,tsx}\"",
-    "build": "tsc && node scripts/renderRealms.mjs"
+    "build": "tsc && node scripts/buildOverlayData.mjs && node scripts/renderRealms.mjs"
   },
   "author": "",
   "license": "MIT",

--- a/scripts/buildOverlayData.mjs
+++ b/scripts/buildOverlayData.mjs
@@ -1,0 +1,16 @@
+import fs from 'fs'
+import path from 'path'
+import util from 'util'
+
+// Load the compiled overlayData from the TypeScript build
+const { overlayData } = await import('../build/data/overlayData.js')
+
+const outputPath = path.join('client', 'scripts', 'overlayData.js')
+
+// Pretty-print using util.inspect to mirror our hand-written style
+const objectLiteral = util.inspect(overlayData, { depth: null, compact: false })
+
+const content = `// Generated from src/data/overlayData.ts\nexport const overlayData = ${objectLiteral};\n\nwindow.overlayData = overlayData;\n`
+
+fs.writeFileSync(outputPath, content)
+console.log('Wrote', outputPath)


### PR DESCRIPTION
## Summary
- add a script to convert overlayData.ts into overlayData.js
- run the new build step as part of `npm run build`
- document the generated overlayData helper in README

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685622fbde4c8325b06ade83da65c59f