### PR TITLE
Enable optional parallax override

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ No additional dependencies are required for watch mode.
 
 ## Star field and parallax
 
-The night sky behind every page is created in `client/scripts/background.js`. It generates twinkling stars and eases them with a simple mouse‑driven parallax so the cosmos gently follows your movement.
+The night sky behind every page is created in `client/scripts/background.js`. It
+generates twinkling stars and eases them with a gentle mouse-driven parallax so
+the cosmos drifts with you. If your operating system prefers reduced motion the
+effect is suppressed for accessibility. Add `?parallax=1` to the URL to force it
+on when needed.
 
 ## Compiling the `src` directory
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ No additional dependencies are required for watch mode.
 The night sky behind every page is created in `client/scripts/background.js`. It
 generates twinkling stars and eases them with a gentle mouse-driven parallax so
 the cosmos drifts with you. If your operating system prefers reduced motion the
-effect is suppressed for accessibility. Add `?parallax=1` to the URL to force it
-on when needed.
+effect is suppressed for accessibility.
+
+To permanently override this, append `?parallax=1` or `?parallax=0` to any page
+URL. The choice is stored in local storage so your preference carries across the
+site.
 
 ## Compiling the `src` directory
 

--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -29,15 +29,30 @@ document.addEventListener('DOMContentLoaded', () => {
     resizeTimeout = setTimeout(generateStars, 200)
   })
 
-  // Parallax effect with optional override
+  // Parallax effect with optional overrides
   const prefersReduced = window.matchMedia(
     '(prefers-reduced-motion: reduce)',
   ).matches
-  // ?parallax=1 can be used to enable motion even when reduced-motion is set
-  const urlParams = new URLSearchParams(window.location.search)
-  const forceParallax = urlParams.get('parallax') === '1'
 
-  if (!prefersReduced || forceParallax) {
+  const urlParams = new URLSearchParams(window.location.search)
+  const param = urlParams.get('parallax')
+
+  try {
+    if (param !== null) localStorage.setItem('parallax', param)
+  } catch (e) {
+    // localStorage may be unavailable; ignore failures
+  }
+
+  let stored = null
+  try {
+    stored = localStorage.getItem('parallax')
+  } catch (e) {}
+
+  let enableParallax = !prefersReduced
+  if (stored === '1') enableParallax = true
+  if (stored === '0') enableParallax = false
+
+  if (enableParallax) {
     let targetX = 0,
       targetY = 0,
       currentX = 0,

--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -29,11 +29,15 @@ document.addEventListener('DOMContentLoaded', () => {
     resizeTimeout = setTimeout(generateStars, 200)
   })
 
-  // Parallax effect
+  // Parallax effect with optional override
   const prefersReduced = window.matchMedia(
     '(prefers-reduced-motion: reduce)',
   ).matches
-  if (!prefersReduced) {
+  // ?parallax=1 can be used to enable motion even when reduced-motion is set
+  const urlParams = new URLSearchParams(window.location.search)
+  const forceParallax = urlParams.get('parallax') === '1'
+
+  if (!prefersReduced || forceParallax) {
     let targetX = 0,
       targetY = 0,
       currentX = 0,


### PR DESCRIPTION
## Summary
- allow `?parallax=1` query to force parallax
- clarify README about parallax override

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857842f82e883258df78eaa8fde29ee