### PR TITLE
Render realm pages to static HTML

### DIFF
--- a/scripts/renderRealms.mjs
+++ b/scripts/renderRealms.mjs
@@ -1,2 +1,42 @@
-console.log('Skipping page generation in test environment')
-process.exit(0)
+import fs from 'fs'
+import path from 'path'
+import React from 'react'
+import ReactDOMServer from 'react-dom/server'
+
+// Compile-time pages and data
+const { realmPages } = await import('../build/pages/realms/index.js')
+const { realms } = await import('../build/data/realmMetadata.js')
+const { realmIcons } = await import('../build/data/realmIcons.js')
+const { loadRealmDetail } = await import('../build/data/realmData.js')
+const RealmTemplate = (await import('../build/components/RealmTemplate.js')).default.default
+
+for (const key of Object.keys(realmPages)) {
+  const realm = realms[key]
+  const detail = await loadRealmDetail(key)
+
+  const element = React.createElement(RealmTemplate, {
+    realmName: realm.realmName,
+    corePlanets: detail.corePlanets,
+    clusters: detail.clusters,
+    icon: realmIcons[key],
+    color: realm.color,
+  })
+
+  const markup = ReactDOMServer.renderToStaticMarkup(element)
+
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../styles/style.css" />
+  </head>
+  <body>
+    <main id="react-root">${markup}</main>
+  </body>
+</html>\n`
+
+  const outPath = path.join('client', 'pages', `${key}.html`)
+  fs.writeFileSync(outPath, html)
+  console.log('Wrote', outPath)
+}


### PR DESCRIPTION
## Summary
- implement page rendering in `renderRealms.mjs`
- generate static realm HTML using `ReactDOMServer`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68578c3130188325a05bb6439b05ae35