### PR TITLE
Add realm page existence checks

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,17 @@ async function run() {
   const buildOutput = path.join(ROOT, 'build', 'data', 'realmData.js')
   assert.ok(fs.existsSync(buildOutput), 'build should create compiled files')
 
+  const { realms: builtRealms } = require('../build/data/realmMetadata.js')
+  for (const [key, meta] of Object.entries(builtRealms)) {
+    const pagePath = path.join(ROOT, 'client', 'pages', `${key}.html`)
+    assert.ok(fs.existsSync(pagePath), `${key}.html should exist after build`)
+    const contents = fs.readFileSync(pagePath, 'utf-8')
+    assert.ok(
+      contents.includes(meta.realmName),
+      `${key}.html should include realm name`,
+    )
+  }
+
   await withServer(async () => {
     const indexPath = path.join(ROOT, 'client', 'index.html')
     assert.ok(fs.existsSync(indexPath), 'index.html should exist')


### PR DESCRIPTION
## Summary
- ensure realm pages are generated during build
- loop through realm metadata and verify generated files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857a407dd4c8325b42c044513b196bf