### PR TITLE
Add TypeScript server build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Static website for Elysium Web",
   "main": "server/server.js",
   "scripts": {
-    "start": "node server/server.js",
+    "start": "node build/server/server.js",
     "test": "node test/test.js",
     "format": "prettier --write \"client/**/*.{js,css,html}\" \"server/**/*.js\" \"test/**/*.js\" \"src/**/*.{ts,tsx}\"",
     "build": "tsc && node scripts/buildOverlayData.mjs && node scripts/renderRealms.mjs"

--- a/scripts/buildOverlayData.mjs
+++ b/scripts/buildOverlayData.mjs
@@ -3,7 +3,7 @@ import path from 'path'
 import util from 'util'
 
 // Load the compiled overlayData from the TypeScript build
-const { overlayData } = await import('../build/data/overlayData.js')
+const { overlayData } = await import('../build/src/data/overlayData.js')
 
 const outputPath = path.join('client', 'scripts', 'overlayData.js')
 

--- a/scripts/renderRealms.mjs
+++ b/scripts/renderRealms.mjs
@@ -4,11 +4,11 @@ import React from 'react'
 import ReactDOMServer from 'react-dom/server'
 
 // Compile-time pages and data
-const { realmPages } = await import('../build/pages/realms/index.js')
-const { realms } = await import('../build/data/realmMetadata.js')
-const { realmIcons } = await import('../build/data/realmIcons.js')
-const { loadRealmDetail } = await import('../build/data/realmData.js')
-const RealmTemplate = (await import('../build/components/RealmTemplate.js')).default.default
+const { realmPages } = await import('../build/src/pages/realms/index.js')
+const { realms } = await import('../build/src/data/realmMetadata.js')
+const { realmIcons } = await import('../build/src/data/realmIcons.js')
+const { loadRealmDetail } = await import('../build/src/data/realmData.js')
+const RealmTemplate = (await import('../build/src/components/RealmTemplate.js')).default.default
 
 for (const key of Object.keys(realmPages)) {
   const realm = realms[key]

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,0 +1,65 @@
+import http, { IncomingMessage, ServerResponse } from 'http'
+import fs from 'fs'
+import path from 'path'
+
+const root = path.join(__dirname, '..', 'client')
+const port = process.env.PORT || 3000
+
+const mimeTypes: Record<string, string> = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+}
+
+// Gracefully send a plain 404 when the requested file slips through our fingers.
+function send404(res: ServerResponse): void {
+  res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+  res.end('Not found')
+}
+
+function serveFile(filePath: string, res: ServerResponse): void {
+  const ext = path.extname(filePath).toLowerCase()
+  const contentType = mimeTypes[ext] || 'application/octet-stream'
+  const stream = fs.createReadStream(filePath)
+  stream.on('error', () => {
+    send404(res)
+  })
+  res.writeHead(200, { 'Content-Type': contentType })
+  stream.pipe(res)
+}
+
+const server = http.createServer((req: IncomingMessage, res: ServerResponse) => {
+  const requestPath = decodeURI((req.url || '').split('?')[0])
+  let filePath = path.normalize(path.join(root, requestPath))
+
+  if (!filePath.startsWith(root)) {
+    send404(res)
+    return
+  }
+
+  if (requestPath === '/' || requestPath.endsWith('/')) {
+    filePath = path.join(filePath, 'index.html')
+  }
+
+  fs.stat(filePath, (err, stats) => {
+    if (err) {
+      send404(res)
+      return
+    }
+    if (stats.isDirectory()) {
+      filePath = path.join(filePath, 'index.html')
+    }
+    serveFile(filePath, res)
+  })
+})
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -44,7 +44,7 @@ async function run() {
   runCommand('npx', ['tsc', '--module', 'commonjs', '--outDir', 'build_test'])
   runCommand('npm', ['run', 'build'])
 
-  const buildOutput = path.join(ROOT, 'build', 'data', 'realmData.js')
+  const buildOutput = path.join(ROOT, 'build', 'src', 'data', 'realmData.js')
   assert.ok(fs.existsSync(buildOutput), 'build should create compiled files')
 
   await withServer(async () => {
@@ -160,8 +160,8 @@ async function run() {
       'overlayData.js should have application/javascript content-type',
     )
 
-    const { loadRealmDetail } = require('../build_test/data/realmData.js')
-    const { realms } = require('../build_test/data/realmMetadata.js')
+    const { loadRealmDetail } = require('../build_test/src/data/realmData.js')
+    const { realms } = require('../build_test/src/data/realmMetadata.js')
     // verify that each realm page is served and contains its name
     for (const [key, meta] of Object.entries(realms)) {
       const realmPage = await fetch(`/pages/${key}.html`)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,12 +6,12 @@
     "jsx": "react",
     "lib": ["dom", "es2019"],
     "types": ["node"],
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "build",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "server/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- implement typed HTTP server in `server/server.ts`
- compile server files by expanding `include` glob in `tsconfig.json`
- build assets in `build/src` and adjust scripts accordingly
- update start script to launch compiled server
- tweak tests for new build layout

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857a41f19a88325be409a46e3e61937