### PR TITLE
Switch overlay data generation to JSON.stringify

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the static assets for the Elysium Web project. The `cli
 Elysium is a digital cosmos shaped by feeling. Every page and line of code aims to evoke honest reflection. To understand the heart behind this project, read the [core philosophy](lore/core.md) and let emotion guide your journey.
 
 ## Running locally
-A small Node server is included to serve the contents of `client/` for development. Run the following commands:
+A small Node server is included to serve the contents of `client/` for development. Run the following command, which builds the TypeScript and then starts the server:
 
 ```bash
 npm start

--- a/client/scripts/overlayData.js
+++ b/client/scripts/overlayData.js
@@ -1,98 +1,98 @@
 // Generated from src/data/overlayData.ts
 export const overlayData = {
-  abyss: {
-    icon: '🕳️',
-    features: [
-      'Silent Chase',
-      'Hollow Veil',
-      'Frozen Nerve',
-      'Bound Breath',
-      'Null Horizon'
+  "abyss": {
+    "icon": "🕳️",
+    "features": [
+      "Silent Chase",
+      "Hollow Veil",
+      "Frozen Nerve",
+      "Bound Breath",
+      "Null Horizon"
     ]
   },
-  cavern: {
-    icon: '🪨',
-    features: [
-      'False Shrine',
-      'Smoky Mirror',
-      'Venom Hold',
-      'Itchy Bite',
-      'Spiky Throne'
+  "cavern": {
+    "icon": "🪨",
+    "features": [
+      "False Shrine",
+      "Smoky Mirror",
+      "Venom Hold",
+      "Itchy Bite",
+      "Spiky Throne"
     ]
   },
-  dross: {
-    icon: '☣️',
-    features: [
-      'Putrid Force',
-      'Tarry Bone',
-      'Stolen Doll',
-      'Pale Shiver'
+  "dross": {
+    "icon": "☣️",
+    "features": [
+      "Putrid Force",
+      "Tarry Bone",
+      "Stolen Doll",
+      "Pale Shiver"
     ]
   },
-  ember: {
-    icon: '🔥',
-    features: [
-      'Infernal Mammoth',
-      'Brazen Rhino',
-      'Noisy Wasp',
-      'Vicious Cobra'
+  "ember": {
+    "icon": "🔥",
+    "features": [
+      "Infernal Mammoth",
+      "Brazen Rhino",
+      "Noisy Wasp",
+      "Vicious Cobra"
     ]
   },
-  glare: {
-    icon: '👁️',
-    features: [
-      'Fallen Eye',
-      'Deadlight Hall',
-      'Raucous Laugh'
+  "glare": {
+    "icon": "👁️",
+    "features": [
+      "Fallen Eye",
+      "Deadlight Hall",
+      "Raucous Laugh"
     ]
   },
-  languish: {
-    icon: '💧',
-    features: [
-      'Glass Crypt',
-      'Blank Prism',
-      'Sapphire Chamber',
-      'Empty House'
+  "languish": {
+    "icon": "💧",
+    "features": [
+      "Glass Crypt",
+      "Blank Prism",
+      "Sapphire Chamber",
+      "Empty House"
     ]
   },
-  mist: {
-    icon: '🌫️',
-    features: [
-      'Lucid Thread',
-      'Ancient Quiet',
-      'Fractal Maze',
-      'Shallow Anchor',
-      'Myriad Glitch'
+  "mist": {
+    "icon": "🌫️",
+    "features": [
+      "Lucid Thread",
+      "Ancient Quiet",
+      "Fractal Maze",
+      "Shallow Anchor",
+      "Myriad Glitch"
     ]
   },
-  oasis: {
-    icon: '🌴',
-    features: [
-      'Verdant Hearth',
-      'Radiant Grove',
-      'Honey Bloom',
-      'Open Palm',
-      'Woven Circle',
-      'Twinkle Toe',
-      'Soft Meadow'
+  "oasis": {
+    "icon": "🌴",
+    "features": [
+      "Verdant Hearth",
+      "Radiant Grove",
+      "Honey Bloom",
+      "Open Palm",
+      "Woven Circle",
+      "Twinkle Toe",
+      "Soft Meadow"
     ]
   },
-  trace: {
-    icon: '🌀',
-    features: [
-      'Sepia Garden',
-      'Word Cemetery',
-      'Aurora Shadow',
-      'Butterfly Canopy'
+  "trace": {
+    "icon": "🌀",
+    "features": [
+      "Sepia Garden",
+      "Word Cemetery",
+      "Aurora Shadow",
+      "Butterfly Canopy"
     ]
   },
-  zenith: {
-    icon: '🚀',
-    features: [
-      'Steadfast Anvil',
-      'Primordial Pillar',
-      'Luminescent Crown',
-      'Omega Threshold'
+  "zenith": {
+    "icon": "🚀",
+    "features": [
+      "Steadfast Anvil",
+      "Primordial Pillar",
+      "Luminescent Crown",
+      "Omega Threshold"
     ]
   }
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Static website for Elysium Web",
   "main": "server/server.js",
   "scripts": {
-    "start": "node build/server/server.js",
+    "start": "npm run build && node build/server/server.js",
     "test": "node test/test.js",
     "format": "prettier --write \"client/**/*.{js,css,html}\" \"server/**/*.js\" \"test/**/*.js\" \"src/**/*.{ts,tsx}\"",
     "build": "tsc && node scripts/buildOverlayData.mjs && node scripts/renderRealms.mjs"

--- a/scripts/buildOverlayData.mjs
+++ b/scripts/buildOverlayData.mjs
@@ -1,16 +1,15 @@
 import fs from 'fs'
 import path from 'path'
-import util from 'util'
 
 // Load the compiled overlayData from the TypeScript build
 const { overlayData } = await import('../build/src/data/overlayData.js')
 
 const outputPath = path.join('client', 'scripts', 'overlayData.js')
 
-// Pretty-print using util.inspect to mirror our hand-written style
-const objectLiteral = util.inspect(overlayData, { depth: null, compact: false })
+// Pretty-print the overlay data as JSON
+const json = JSON.stringify(overlayData, null, 2)
 
-const content = `// Generated from src/data/overlayData.ts\nexport const overlayData = ${objectLiteral};\n\nwindow.overlayData = overlayData;\n`
+const content = `// Generated from src/data/overlayData.ts\nexport const overlayData = ${json};\n\nwindow.overlayData = overlayData;\n`
 
 fs.writeFileSync(outputPath, content)
 console.log('Wrote', outputPath)

--- a/server/server.ts
+++ b/server/server.ts
@@ -2,7 +2,13 @@ import http, { IncomingMessage, ServerResponse } from 'http'
 import fs from 'fs'
 import path from 'path'
 
-const root = path.join(__dirname, '..', 'client')
+// Locate the client folder whether we're running from the TypeScript sources
+// or the compiled build output. When running `npm start` the server lives in
+// `build/server`, otherwise it's inside `server`.
+const builtRoot = path.join(__dirname, '..', 'client')
+const root = fs.existsSync(builtRoot)
+  ? builtRoot
+  : path.join(__dirname, '..', '..', 'client')
 const port = process.env.PORT || 3000
 
 const mimeTypes: Record<string, string> = {

--- a/test/test.js
+++ b/test/test.js
@@ -50,7 +50,7 @@ async function run() {
   const buildOutput = path.join(ROOT, 'build', 'src', 'data', 'realmData.js')
   assert.ok(fs.existsSync(buildOutput), 'build should create compiled files')
 
-  const { realms: builtRealms } = require('../build/data/realmMetadata.js')
+  const { realms: builtRealms } = require('../build/src/data/realmMetadata.js')
   for (const [key, meta] of Object.entries(builtRealms)) {
     const pagePath = path.join(ROOT, 'client', 'pages', `${key}.html`)
     assert.ok(fs.existsSync(pagePath), `${key}.html should exist after build`)


### PR DESCRIPTION
## Summary
- generate overlay script with `JSON.stringify` instead of `util.inspect`
- update server tests for new build path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857a7034834832596c282d3f8cd7856