### PR TITLE
Improve star overlay accessibility

### DIFF
--- a/client/scripts/stars.js
+++ b/client/scripts/stars.js
@@ -25,12 +25,15 @@
 
       const overlay = document.createElement('div')
       overlay.id = 'star-overlay'
+      overlay.setAttribute('role', 'dialog')
+      overlay.setAttribute('aria-live', 'polite')
       const list = document.createElement('ul')
 
       TRUTHS.forEach((truth) => {
         const btn = document.createElement('button')
         btn.className = 'truth-btn'
         btn.textContent = truth
+        btn.setAttribute('aria-live', 'polite')
         btn.addEventListener('click', () => {
           try {
             localStorage.setItem(`elysium-truth-${realm}`, truth)

--- a/test/test.js
+++ b/test/test.js
@@ -235,8 +235,25 @@ async function run() {
     const starIcon = dom.window.document.querySelector('.collect-star')
     assert.ok(starIcon, 'star icon should be injected')
     starIcon.click()
+    const overlayEl = dom.window.document.getElementById('star-overlay')
+    assert.ok(overlayEl, 'overlay element should exist')
+    assert.strictEqual(
+      overlayEl.getAttribute('role'),
+      'dialog',
+      'overlay should have dialog role',
+    )
+    assert.strictEqual(
+      overlayEl.getAttribute('aria-live'),
+      'polite',
+      'overlay should be aria-live polite',
+    )
     const firstOption = dom.window.document.querySelector('#star-overlay button')
     assert.ok(firstOption, 'overlay should show truth options')
+    assert.strictEqual(
+      firstOption.getAttribute('aria-live'),
+      'polite',
+      'truth button should have aria-live',
+    )
     firstOption.click()
     assert.ok(
       dom.window.localStorage.getItem('elysium-truth-testrealm'),


### PR DESCRIPTION
## Summary
- add `role="dialog"` and `aria-live="polite"` to the star overlay
- apply `aria-live` to overlay option buttons
- extend tests to assert these accessibility attributes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857aba897bc8325b49d6cece6e8e621