### PR TITLE
Add nav fallback and test for failed fetch

### DIFF
--- a/client/scripts/nav.js
+++ b/client/scripts/nav.js
@@ -5,18 +5,28 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!placeholder) return
 
   fetch('../partials/nav.html')
-    .then(res => res.text())
-    .then(html => {
+    .then((res) => res.text())
+    .then((html) => {
       placeholder.outerHTML = html
       const nav = document.getElementById('main-nav')
       highlightCurrentPage(nav)
       enableRipples(nav)
     })
-    .catch(err => console.error('Navigation failed to load', err))
+    .catch((err) => {
+      console.error('Navigation failed to load', err)
+      placeholder.innerHTML = [
+        '<a href="home.html">Home</a>',
+        '<a href="profile.html">Profile</a>',
+        '<a href="explore.html">Explore</a>',
+        '<a href="about.html">About</a>',
+        '<a href="universe.html">Universe</a>',
+      ].join(' ')
+      highlightCurrentPage(placeholder)
+    })
 
   function highlightCurrentPage(nav) {
     const page = window.location.pathname.split('/').pop()
-    nav.querySelectorAll('a[href]:not(.brand-link)').forEach(link => {
+    nav.querySelectorAll('a[href]:not(.brand-link)').forEach((link) => {
       if (link.getAttribute('href') === page) {
         link.setAttribute('aria-current', 'page')
       }
@@ -24,8 +34,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function enableRipples(nav) {
-    nav.querySelectorAll('a:not(.brand-link)').forEach(link => {
-      link.addEventListener('click', event => {
+    nav.querySelectorAll('a:not(.brand-link)').forEach((link) => {
+      link.addEventListener('click', (event) => {
         event.preventDefault()
         if (window.createRainbowRipple) {
           createRainbowRipple(link, event, () => {

--- a/test/test.js
+++ b/test/test.js
@@ -113,11 +113,7 @@ async function run() {
     )
 
     const about = await fetch('/pages/about.html')
-    assert.strictEqual(
-      about.statusCode,
-      200,
-      'about page should return 200',
-    )
+    assert.strictEqual(about.statusCode, 200, 'about page should return 200')
     assert.ok(
       about.data.includes('About Elysium'),
       'about page should contain about heading',
@@ -155,7 +151,6 @@ async function run() {
       navPartial.data.includes('<nav'),
       'nav partial should contain nav element',
     )
-
 
     const universeScript = await fetch('/scripts/universe.js')
     assert.strictEqual(
@@ -235,12 +230,37 @@ async function run() {
     const starIcon = dom.window.document.querySelector('.collect-star')
     assert.ok(starIcon, 'star icon should be injected')
     starIcon.click()
-    const firstOption = dom.window.document.querySelector('#star-overlay button')
+    const firstOption = dom.window.document.querySelector(
+      '#star-overlay button',
+    )
     assert.ok(firstOption, 'overlay should show truth options')
     firstOption.click()
     assert.ok(
       dom.window.localStorage.getItem('elysium-truth-testrealm'),
       'selecting a truth should store value in localStorage',
+    )
+
+    const navScript = fs.readFileSync(
+      path.join(ROOT, 'client', 'scripts', 'nav.js'),
+      'utf-8',
+    )
+    const navDom = new JSDOM(
+      '<!doctype html><html><body><nav id="main-nav" aria-label="primary"></nav></body></html>',
+      {
+        runScripts: 'dangerously',
+        url: 'https://example.com/pages/zenith.html',
+      },
+    )
+    navDom.window.fetch = () => Promise.reject(new Error('fail'))
+    navDom.window.eval(navScript)
+    navDom.window.document.dispatchEvent(
+      new navDom.window.Event('DOMContentLoaded'),
+    )
+    await wait(0)
+    const fallbackNav = navDom.window.document.querySelector('#main-nav')
+    assert.ok(
+      fallbackNav.querySelector('a[href="home.html"]'),
+      'fallback nav should show links when fetch fails',
     )
 
     console.log('All tests passed.')


### PR DESCRIPTION
## Summary
- inject simple links when `nav.html` fails to load
- test that `nav.js` inserts fallback links if `fetch` rejects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857abb7fe34832595b04f95b6273393