### PR TITLE
Enhance visual consistency

### DIFF
--- a/client/partials/nav.html
+++ b/client/partials/nav.html
@@ -1,7 +1,7 @@
 <!-- Shared navigation used across all inner pages -->
 <nav id="main-nav" aria-label="primary">
   <div class="brand">
-    <a href="home.html" class="brand-link">Elysium</a>
+    <a href="home.html" class="brand-link" aria-label="Elysium home">Elysium</a>
   </div>
   <ul>
     <li><a href="home.html">Home</a></li>

--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -30,12 +30,43 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     // Gradient colors
-    const gradients = [
-        ["#000000", "#020c1b", "#0a1f44", "#273a7f"], // Deep blue night set
-        ["#020c1b", "#0a1f44", "#273a7f", "#3b3f80"], // Twilight indigo set
-        ["#0a1f44", "#273a7f", "#3b3f80", "#484c91"], // Celestial purple set
-        ["#273a7f", "#3b3f80", "#484c91", "#2a2e5a"], // Cosmic dusk set
-    ];
+    function adjust(hex, amt) {
+        const col = hex.startsWith('#') ? hex.slice(1) : hex
+        const num = parseInt(col, 16)
+        const r = (num >> 16) + amt
+        const g = ((num >> 8) & 0xff) + amt
+        const b = (num & 0xff) + amt
+        return (
+            '#' +
+            (
+                0x1000000 +
+                (Math.max(0, Math.min(255, r)) << 16) +
+                (Math.max(0, Math.min(255, g)) << 8) +
+                Math.max(0, Math.min(255, b))
+            )
+                .toString(16)
+                .slice(1)
+        )
+    }
+
+    function buildGradients(base) {
+        return [
+            [adjust(base, -120), adjust(base, -80), adjust(base, -40), base],
+            [adjust(base, -80), adjust(base, -40), base, adjust(base, 40)],
+            [adjust(base, -40), base, adjust(base, 40), adjust(base, 80)],
+            [base, adjust(base, 40), adjust(base, 80), adjust(base, 40)],
+        ]
+    }
+
+    const realmEl = document.querySelector('.realm')
+    const realmColor =
+        realmEl && getComputedStyle(realmEl).getPropertyValue('--realm-color')
+    const gradients = realmColor ? buildGradients(realmColor.trim()) : [
+        ["#000000", "#020c1b", "#0a1f44", "#273a7f"],
+        ["#020c1b", "#0a1f44", "#273a7f", "#3b3f80"],
+        ["#0a1f44", "#273a7f", "#3b3f80", "#484c91"],
+        ["#273a7f", "#3b3f80", "#484c91", "#2a2e5a"],
+    ]
 
     let currentGradientIndex = 0;
     function updateGradients() {

--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -49,12 +49,45 @@ document.addEventListener("DOMContentLoaded", () => {
         )
     }
 
+    function toRgba(hex, alpha) {
+        const col = hex.startsWith('#') ? hex.slice(1) : hex
+        const num = parseInt(col, 16)
+        const r = num >> 16
+        const g = (num >> 8) & 0xff
+        const b = num & 0xff
+        return `rgba(${r}, ${g}, ${b}, ${alpha})`
+    }
+
     function buildGradients(base) {
+        const bodyStyles = getComputedStyle(document.body)
+        const alpha = parseFloat(
+            bodyStyles.getPropertyValue('--gradient-alpha') || '0.75',
+        )
         return [
-            [adjust(base, -120), adjust(base, -80), adjust(base, -40), base],
-            [adjust(base, -80), adjust(base, -40), base, adjust(base, 40)],
-            [adjust(base, -40), base, adjust(base, 40), adjust(base, 80)],
-            [base, adjust(base, 40), adjust(base, 80), adjust(base, 40)],
+            [
+                toRgba(adjust(base, -160), alpha),
+                toRgba(adjust(base, -120), alpha),
+                toRgba(adjust(base, -80), alpha),
+                toRgba(adjust(base, -40), alpha),
+            ],
+            [
+                toRgba(adjust(base, -120), alpha),
+                toRgba(adjust(base, -80), alpha),
+                toRgba(adjust(base, -40), alpha),
+                toRgba(base, alpha),
+            ],
+            [
+                toRgba(adjust(base, -80), alpha),
+                toRgba(adjust(base, -40), alpha),
+                toRgba(base, alpha),
+                toRgba(adjust(base, 40), alpha),
+            ],
+            [
+                toRgba(adjust(base, -40), alpha),
+                toRgba(base, alpha),
+                toRgba(adjust(base, 40), alpha),
+                toRgba(adjust(base, -20), alpha),
+            ],
         ]
     }
 

--- a/client/scripts/ripple.js
+++ b/client/scripts/ripple.js
@@ -14,13 +14,18 @@
     if (styles.position === 'static') element.style.position = 'relative'
     if (styles.overflow !== 'hidden') element.style.overflow = 'hidden'
 
-    const hue = Math.floor(Math.random() * 360)
+    function hexWithAlpha(hex, alpha) {
+      const value = hex.replace('#', '')
+      return `#${value}${alpha}`
+    }
+    const computed = getComputedStyle(element)
+    const base = (computed.getPropertyValue('--ripple-color') || '#ff69b4').trim()
     ring.style.background = `radial-gradient(circle,
-      hsla(${hue},100%,70%,0) 40%,
-      hsla(${hue},100%,70%,1) 45%,
-      hsla(${hue},100%,70%,1) 50%,
-      hsla(${hue},100%,70%,0) 55%)`
-    ring.style.boxShadow = `0 0 6px hsla(${hue},100%,70%,0.9)`
+      ${hexWithAlpha(base, '00')} 40%,
+      ${hexWithAlpha(base, 'ff')} 45%,
+      ${hexWithAlpha(base, 'ff')} 50%,
+      ${hexWithAlpha(base, '00')} 55%)`
+    ring.style.boxShadow = `0 0 6px ${hexWithAlpha(base, 'e6')}`
 
     element.appendChild(ring)
     ring.addEventListener(

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -6,12 +6,13 @@
   /* Slightly wider spacing for clarity */
   --primary-spacing: 1.5px;
   --ripple-color: var(--realm-color, #ff69b4);
+  --gradient-alpha: 0.75;
   --default-gradient: linear-gradient(
     to bottom,
-    #000000,
-    #020c1b,
-    #0a1f44,
-    #273a7f
+    rgba(0, 0, 0, var(--gradient-alpha, 0.75)),
+    rgba(2, 12, 27, var(--gradient-alpha, 0.75)),
+    rgba(10, 31, 68, var(--gradient-alpha, 0.75)),
+    rgba(39, 58, 127, var(--gradient-alpha, 0.75))
   );
 }
 

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -2,9 +2,10 @@
 
 :root {
   --primary-font: 'Orbitron', 'Arial Narrow', Arial, sans-serif;
-  --primary-color: #ffeeee;
+  --primary-color: #ffcccc;
   /* Slightly wider spacing for clarity */
   --primary-spacing: 1.5px;
+  --ripple-color: var(--realm-color, #ff69b4);
 }
 
 html,
@@ -272,6 +273,23 @@ h1 {
     flex-direction: column;
     gap: 12px;
     align-items: center;
+  }
+}
+
+@media (min-width: 601px) and (max-width: 1024px) {
+  #main-nav {
+    gap: 24px;
+    padding: 20px 28px;
+  }
+  #main-nav ul {
+    gap: 20px;
+  }
+}
+
+@media (min-width: 1025px) {
+  #main-nav {
+    gap: 32px;
+    padding: 24px 40px;
   }
 }
 

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -6,6 +6,13 @@
   /* Slightly wider spacing for clarity */
   --primary-spacing: 1.5px;
   --ripple-color: var(--realm-color, #ff69b4);
+  --default-gradient: linear-gradient(
+    to bottom,
+    #000000,
+    #020c1b,
+    #0a1f44,
+    #273a7f
+  );
 }
 
 html,
@@ -71,17 +78,9 @@ body {
   font-family: var(--primary-font);
   color: var(--primary-color);
   letter-spacing: var(--primary-spacing);
-  background: linear-gradient(
-    -45deg,
-    #000000,
-    #120022,
-    #290136,
-    #3d0075,
-    #400144,
-    #3d0075,
-    #290136,
-    #120022,
-    #020131
+  background: var(
+    --gradient-current,
+    var(--default-gradient)
   );
   background-size: 400% 400%;
   animation: gradientCycle 60s ease-in-out infinite;

--- a/client/styles/universe.css
+++ b/client/styles/universe.css
@@ -1,3 +1,15 @@
+:root {
+  --overlay-color-1: #000000;
+  --overlay-color-2: #120022;
+  --overlay-color-3: #290136;
+  --overlay-color-4: #3d0075;
+  --overlay-color-5: #400144;
+  --overlay-color-6: #3d0075;
+  --overlay-color-7: #290136;
+  --overlay-color-8: #120022;
+  --overlay-color-9: #020131;
+}
+
 #gradientOverlay {
   position: fixed;
   top: 0;
@@ -8,15 +20,15 @@
   opacity: 0.65;
   background: linear-gradient(
     -45deg,
-    #000000,
-    #120022,
-    #290136,
-    #3d0075,
-    #400144,
-    #3d0075,
-    #290136,
-    #120022,
-    #020131
+    var(--overlay-color-1, #000000),
+    var(--overlay-color-2, #120022),
+    var(--overlay-color-3, #290136),
+    var(--overlay-color-4, #3d0075),
+    var(--overlay-color-5, #400144),
+    var(--overlay-color-6, #3d0075),
+    var(--overlay-color-7, #290136),
+    var(--overlay-color-8, #120022),
+    var(--overlay-color-9, #020131)
   );
   background-size: 400% 400%;
   animation: gradientCycle 60s ease-in-out infinite;

--- a/client/styles/universe.css
+++ b/client/styles/universe.css
@@ -8,6 +8,7 @@
   --overlay-color-7: #290136;
   --overlay-color-8: #120022;
   --overlay-color-9: #020131;
+  --overlay-alpha: 0.55;
 }
 
 #gradientOverlay {
@@ -17,7 +18,7 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
-  opacity: 0.65;
+  opacity: var(--overlay-alpha, 0.65);
   background: linear-gradient(
     -45deg,
     var(--overlay-color-1, #000000),

--- a/src/components/RealmTemplate.tsx
+++ b/src/components/RealmTemplate.tsx
@@ -19,7 +19,10 @@ const RealmTemplate: React.FC<RealmTemplateProps> = ({
   return (
     <div
       className={`realm realm-${realmName.toLowerCase()}`}
-      style={{ '--realm-color': color } as React.CSSProperties}
+      style={{
+        '--realm-color': color,
+        '--ripple-color': color,
+      } as React.CSSProperties}
     >
       <h1>{realmName}</h1>
       <section id="realm-space" className="realm-section">


### PR DESCRIPTION
## Summary
- improve default text color and add ripple color variable
- tune navigation responsiveness for tablets and large screens
- expose overlay gradient colors as CSS vars
- add aria label on brand link
- link ripple effect and background gradients to realm colors

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857cb4168a48325bc26f60a7571a9d2