### PR TITLE
Improve star field and transitions

### DIFF
--- a/client/pages/about.html
+++ b/client/pages/about.html
@@ -140,58 +140,101 @@
             Elysium is composed of ten realms reflected in
             <code>src/data/realmMetadata.ts</code>:
           </p>
-          <ul>
-            <li>
-              <span class="realm-name realm-oasis">🌴 Oasis</span>
-              – A refuge of belonging and grateful joy. Peaceful meadows share
-              space with playful springs, nurturing contentment and gentle love.
-            </li>
-            <li>
-              <span class="realm-name realm-abyss">🕳️ Abyss</span>
-              – Depths etched by fear, helplessness, and rising panic. Numb
-              isolation and hopeless dread echo through the void.
-            </li>
-            <li>
-              <span class="realm-name realm-zenith">🚀 Zenith</span>
-              – The summit of empowerment and pride. Resilience rings like an
-              anvil as liberation brightens the horizon.
-            </li>
-            <li>
-              <span class="realm-name realm-languish">💧 Languish</span>
-              – A cold plateau where despair and grief settle. Numb detachment
-              and isolation drift like heavy fog.
-            </li>
-            <li>
-              <span class="realm-name realm-cavern">🪨 Cavern</span>
-              – Twisting tunnels of jealousy and contempt. Idolization curdles
-              into obsession while bitterness festers in the dark.
-            </li>
-            <li>
-              <span class="realm-name realm-dross">☣️ Dross</span>
-              – A wasteland steeped in revulsion and self-loathing. Violation
-              leaves stains longing to be cleansed.
-            </li>
-            <li>
-              <span class="realm-name realm-ember">🔥 Ember</span>
-              – Fields of frustration and reckless daring. Rage smolders beside
-              impatience and aggressive sparks.
-            </li>
-            <li>
-              <span class="realm-name realm-glare">👁️ Glare</span>
-              – A searing stage of shame and judgment. Repressed tension
-              magnifies every flaw.
-            </li>
-            <li>
-              <span class="realm-name realm-mist">🌫️ Mist</span>
-              – A labyrinth of curiosity and doubt. Confusion mingles with
-              surreal wonder along shifting paths.
-            </li>
-            <li>
-              <span class="realm-name realm-trace">🌀 Trace</span>
-              – Trails of nostalgia and yearning. Regret and wistful daydreams
-              flicker through memory.
-            </li>
-          </ul>
+          <table class="realm-table">
+            <tbody>
+              <tr>
+                <th scope="row">
+                  <span class="realm-name realm-oasis">🌴 Oasis</span>
+                </th>
+                <td>
+                  A refuge of belonging and grateful joy. Peaceful meadows share
+                  space with playful springs, nurturing contentment and gentle
+                  love.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <span class="realm-name realm-abyss">🕳️ Abyss</span>
+                </th>
+                <td>
+                  Depths etched by fear, helplessness, and rising panic. Numb
+                  isolation and hopeless dread echo through the void.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <span class="realm-name realm-zenith">🚀 Zenith</span>
+                </th>
+                <td>
+                  The summit of empowerment and pride. Resilience rings like an
+                  anvil as liberation brightens the horizon.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <span class="realm-name realm-languish">💧 Languish</span>
+                </th>
+                <td>
+                  A cold plateau where despair and grief settle. Numb detachment
+                  and isolation drift like heavy fog.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <span class="realm-name realm-cavern">🪨 Cavern</span>
+                </th>
+                <td>
+                  Twisting tunnels of jealousy and contempt. Idolization curdles
+                  into obsession while bitterness festers in the dark.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <span class="realm-name realm-dross">☣️ Dross</span>
+                </th>
+                <td>
+                  A wasteland steeped in revulsion and self-loathing. Violation
+                  leaves stains longing to be cleansed.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <span class="realm-name realm-ember">🔥 Ember</span>
+                </th>
+                <td>
+                  Fields of frustration and reckless daring. Rage smolders beside
+                  impatience and aggressive sparks.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <span class="realm-name realm-glare">👁️ Glare</span>
+                </th>
+                <td>
+                  A searing stage of shame and judgment. Repressed tension
+                  magnifies every flaw.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <span class="realm-name realm-mist">🌫️ Mist</span>
+                </th>
+                <td>
+                  A labyrinth of curiosity and doubt. Confusion mingles with
+                  surreal wonder along shifting paths.
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <span class="realm-name realm-trace">🌀 Trace</span>
+                </th>
+                <td>
+                  Trails of nostalgia and yearning. Regret and wistful daydreams
+                  flicker through memory.
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </section>
         <section id="future-vision" class="elysium-section">
           <h2 class="stellar-heading">

--- a/client/pages/abyss.html
+++ b/client/pages/abyss.html
@@ -7,7 +7,7 @@
     <title>Abyss Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.55;">
+  <body class="realm-page" style="--gradient-alpha:0.35;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/abyss.html
+++ b/client/pages/abyss.html
@@ -7,7 +7,7 @@
     <title>Abyss Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.35;">
+  <body class="realm-page">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/abyss.html
+++ b/client/pages/abyss.html
@@ -7,7 +7,7 @@
     <title>Abyss Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body>
+  <body class="realm-page" style="--gradient-alpha:0.85;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/abyss.html
+++ b/client/pages/abyss.html
@@ -7,7 +7,7 @@
     <title>Abyss Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.85;">
+  <body class="realm-page" style="--gradient-alpha:0.55;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/cavern.html
+++ b/client/pages/cavern.html
@@ -7,7 +7,7 @@
     <title>Cavern Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body>
+  <body class="realm-page" style="--gradient-alpha:0.85;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/cavern.html
+++ b/client/pages/cavern.html
@@ -7,7 +7,7 @@
     <title>Cavern Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.85;">
+  <body class="realm-page" style="--gradient-alpha:0.55;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/cavern.html
+++ b/client/pages/cavern.html
@@ -7,7 +7,7 @@
     <title>Cavern Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.55;">
+  <body class="realm-page" style="--gradient-alpha:0.35;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/cavern.html
+++ b/client/pages/cavern.html
@@ -7,7 +7,7 @@
     <title>Cavern Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.35;">
+  <body class="realm-page">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/dross.html
+++ b/client/pages/dross.html
@@ -7,7 +7,7 @@
     <title>Dross Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.55;">
+  <body class="realm-page" style="--gradient-alpha:0.35;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/dross.html
+++ b/client/pages/dross.html
@@ -7,7 +7,7 @@
     <title>Dross Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.85;">
+  <body class="realm-page" style="--gradient-alpha:0.55;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/dross.html
+++ b/client/pages/dross.html
@@ -7,7 +7,7 @@
     <title>Dross Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body>
+  <body class="realm-page" style="--gradient-alpha:0.85;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/dross.html
+++ b/client/pages/dross.html
@@ -7,7 +7,7 @@
     <title>Dross Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.35;">
+  <body class="realm-page">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/ember.html
+++ b/client/pages/ember.html
@@ -7,7 +7,7 @@
     <title>Ember Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.35;">
+  <body class="realm-page">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/ember.html
+++ b/client/pages/ember.html
@@ -7,7 +7,7 @@
     <title>Ember Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.85;">
+  <body class="realm-page" style="--gradient-alpha:0.55;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/ember.html
+++ b/client/pages/ember.html
@@ -7,7 +7,7 @@
     <title>Ember Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.55;">
+  <body class="realm-page" style="--gradient-alpha:0.35;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/ember.html
+++ b/client/pages/ember.html
@@ -7,7 +7,7 @@
     <title>Ember Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body>
+  <body class="realm-page" style="--gradient-alpha:0.85;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/glare.html
+++ b/client/pages/glare.html
@@ -7,7 +7,7 @@
     <title>Glare Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body>
+  <body class="realm-page" style="--gradient-alpha:0.85;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/glare.html
+++ b/client/pages/glare.html
@@ -7,7 +7,7 @@
     <title>Glare Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.85;">
+  <body class="realm-page" style="--gradient-alpha:0.55;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/glare.html
+++ b/client/pages/glare.html
@@ -7,7 +7,7 @@
     <title>Glare Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.55;">
+  <body class="realm-page" style="--gradient-alpha:0.35;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/glare.html
+++ b/client/pages/glare.html
@@ -7,7 +7,7 @@
     <title>Glare Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.35;">
+  <body class="realm-page">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/home.html
+++ b/client/pages/home.html
@@ -30,56 +30,6 @@
           <h2 class="stellar-heading">Badges</h2>
           <p>Your achievements will shimmer here soon.</p>
         </section>
-        <section id="checkin-main" class="home-section">
-          <h2 class="stellar-heading">Daily Check-In</h2>
-          <form id="checkin-form" class="form" aria-describedby="checkin-desc">
-            <p id="checkin-desc" class="visually-hidden">
-              Answer the following questions to chart your emotional course.
-            </p>
-            <label for="q1">Energy Levels</label>
-            <select id="q1" name="q1">
-              <option value="1">1 - Exhausted</option>
-              <option value="2">2</option>
-              <option value="3">3</option>
-              <option value="4">4</option>
-              <option value="5">5 - Vibrant</option>
-            </select>
-            <label for="q2">Mood Brightness</label>
-            <select id="q2" name="q2">
-              <option value="1">1 - Heavy</option>
-              <option value="2">2</option>
-              <option value="3">3</option>
-              <option value="4">4</option>
-              <option value="5">5 - Radiant</option>
-            </select>
-            <label for="q3">Connection to Others</label>
-            <select id="q3" name="q3">
-              <option value="1">1 - Isolated</option>
-              <option value="2">2</option>
-              <option value="3">3</option>
-              <option value="4">4</option>
-              <option value="5">5 - Supported</option>
-            </select>
-            <label for="q4">Mental Clarity</label>
-            <select id="q4" name="q4">
-              <option value="1">1 - Foggy</option>
-              <option value="2">2</option>
-              <option value="3">3</option>
-              <option value="4">4</option>
-              <option value="5">5 - Focused</option>
-            </select>
-            <label for="q5">Stress Levels</label>
-            <select id="q5" name="q5">
-              <option value="1">1 - Overwhelmed</option>
-              <option value="2">2</option>
-              <option value="3">3</option>
-              <option value="4">4</option>
-              <option value="5">5 - Calm</option>
-            </select>
-            <button type="submit" class="submit-btn">Reveal My Planet</button>
-          </form>
-          <div id="result" class="hidden" aria-live="polite"></div>
-        </section>
       </div>
       <section id="feed-section" class="home-section">
         <h2 class="stellar-heading">Live Feed</h2>
@@ -118,6 +68,5 @@
     <script defer src="../scripts/background.js"></script>
     <script defer src="../scripts/ripple.js"></script>
     <script defer src="../scripts/nav.js"></script>
-    <script defer src="../scripts/checkin.js"></script>
   </body>
 </html>

--- a/client/pages/languish.html
+++ b/client/pages/languish.html
@@ -7,7 +7,7 @@
     <title>Languish Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body>
+  <body class="realm-page" style="--gradient-alpha:0.85;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/languish.html
+++ b/client/pages/languish.html
@@ -7,7 +7,7 @@
     <title>Languish Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.55;">
+  <body class="realm-page" style="--gradient-alpha:0.35;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/languish.html
+++ b/client/pages/languish.html
@@ -7,7 +7,7 @@
     <title>Languish Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.85;">
+  <body class="realm-page" style="--gradient-alpha:0.55;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/languish.html
+++ b/client/pages/languish.html
@@ -7,7 +7,7 @@
     <title>Languish Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.35;">
+  <body class="realm-page">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/mist.html
+++ b/client/pages/mist.html
@@ -7,7 +7,7 @@
     <title>Mist Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body>
+  <body class="realm-page" style="--gradient-alpha:0.85;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/mist.html
+++ b/client/pages/mist.html
@@ -7,7 +7,7 @@
     <title>Mist Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.35;">
+  <body class="realm-page">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/mist.html
+++ b/client/pages/mist.html
@@ -7,7 +7,7 @@
     <title>Mist Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.55;">
+  <body class="realm-page" style="--gradient-alpha:0.35;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/mist.html
+++ b/client/pages/mist.html
@@ -7,7 +7,7 @@
     <title>Mist Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.85;">
+  <body class="realm-page" style="--gradient-alpha:0.55;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/oasis.html
+++ b/client/pages/oasis.html
@@ -7,7 +7,7 @@
     <title>Oasis Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body>
+  <body class="realm-page" style="--gradient-alpha:0.85;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/oasis.html
+++ b/client/pages/oasis.html
@@ -7,7 +7,7 @@
     <title>Oasis Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.55;">
+  <body class="realm-page" style="--gradient-alpha:0.35;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/oasis.html
+++ b/client/pages/oasis.html
@@ -7,7 +7,7 @@
     <title>Oasis Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.35;">
+  <body class="realm-page">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/oasis.html
+++ b/client/pages/oasis.html
@@ -7,7 +7,7 @@
     <title>Oasis Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.85;">
+  <body class="realm-page" style="--gradient-alpha:0.55;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/trace.html
+++ b/client/pages/trace.html
@@ -7,7 +7,7 @@
     <title>Trace Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body>
+  <body class="realm-page" style="--gradient-alpha:0.85;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/trace.html
+++ b/client/pages/trace.html
@@ -7,7 +7,7 @@
     <title>Trace Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.85;">
+  <body class="realm-page" style="--gradient-alpha:0.55;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/trace.html
+++ b/client/pages/trace.html
@@ -7,7 +7,7 @@
     <title>Trace Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.35;">
+  <body class="realm-page">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/trace.html
+++ b/client/pages/trace.html
@@ -7,7 +7,7 @@
     <title>Trace Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.55;">
+  <body class="realm-page" style="--gradient-alpha:0.35;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/zenith.html
+++ b/client/pages/zenith.html
@@ -7,7 +7,7 @@
     <title>Zenith Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.85;">
+  <body class="realm-page" style="--gradient-alpha:0.55;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/zenith.html
+++ b/client/pages/zenith.html
@@ -7,7 +7,7 @@
     <title>Zenith Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.35;">
+  <body class="realm-page">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/zenith.html
+++ b/client/pages/zenith.html
@@ -7,7 +7,7 @@
     <title>Zenith Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body>
+  <body class="realm-page" style="--gradient-alpha:0.85;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/pages/zenith.html
+++ b/client/pages/zenith.html
@@ -7,7 +7,7 @@
     <title>Zenith Realm</title>
     <link rel="stylesheet" href="../styles/style.css" />
   </head>
-  <body class="realm-page" style="--gradient-alpha:0.55;">
+  <body class="realm-page" style="--gradient-alpha:0.35;">
     <div id="fadeOverlay" class="start"></div>
     <div id="nebula-container">
       <div class="nebula" id="nebula1"></div>

--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -2,31 +2,54 @@ document.addEventListener("DOMContentLoaded", () => {
     const starsContainer = document.getElementById("stars");
     if (!starsContainer) return;
 
-    // Star generation
-    function generateStars() {
-        starsContainer.innerHTML = "";
-        // more stars by increasing density
-        const DENSITY = 4000;
-        const count = Math.floor((window.innerWidth * window.innerHeight) / DENSITY);
-        const frag = document.createDocumentFragment();
-        for (let i = 0; i < count; i++) {
-            const star = document.createElement("div");
-            star.classList.add("star");
-            star.style.left = `${Math.random() * window.innerWidth}px`;
-            star.style.top = `${Math.random() * window.innerHeight}px`;
-            star.style.animationDuration = `${Math.random() * 3 + 2}s`;
-            star.style.opacity = Math.random();
-            frag.appendChild(star);
-        }
-        starsContainer.appendChild(frag);
+    // Star generation with a fixed pool
+    const STAR_COUNT = 2000;
+    const stars = [];
+
+    function createStar() {
+        const star = document.createElement("div");
+        star.classList.add("star");
+        star.style.animationDuration = `${Math.random() * 3 + 2}s`;
+        star.style.opacity = Math.random().toString();
+        starsContainer.appendChild(star);
+        return star;
     }
 
-    generateStars();
+    function positionStar(star, width, height) {
+        star.style.left = `${Math.random() * width}px`;
+        star.style.top = `${Math.random() * height}px`;
+    }
+
+    function initStars() {
+        const width = document.documentElement.clientWidth;
+        const height = Math.max(
+            document.body.scrollHeight,
+            document.documentElement.clientHeight,
+        );
+        starsContainer.style.height = `${height}px`;
+        for (let i = 0; i < STAR_COUNT; i++) {
+            const star = createStar();
+            positionStar(star, width, height);
+            stars.push(star);
+        }
+    }
+
+    function repositionStars() {
+        const width = document.documentElement.clientWidth;
+        const height = Math.max(
+            document.body.scrollHeight,
+            document.documentElement.clientHeight,
+        );
+        starsContainer.style.height = `${height}px`;
+        stars.forEach((star) => positionStar(star, width, height));
+    }
+
+    initStars();
 
     let resizeTimeout;
     window.addEventListener("resize", () => {
         clearTimeout(resizeTimeout);
-        resizeTimeout = setTimeout(generateStars, 200);
+        resizeTimeout = setTimeout(repositionStars, 150);
     });
 
     // Gradient colors

--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -3,12 +3,13 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!starsContainer) return;
 
     // Star generation
-    const STAR_COUNT = 500;
-
     function generateStars() {
         starsContainer.innerHTML = "";
+        // more stars by increasing density
+        const DENSITY = 4000;
+        const count = Math.floor((window.innerWidth * window.innerHeight) / DENSITY);
         const frag = document.createDocumentFragment();
-        for (let i = 0; i < STAR_COUNT; i++) {
+        for (let i = 0; i < count; i++) {
             const star = document.createElement("div");
             star.classList.add("star");
             star.style.left = `${Math.random() * window.innerWidth}px`;

--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -3,43 +3,29 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!starsContainer) return;
 
     // Star generation
-    const STAR_COUNT = 250;
-    const stars = [];
+    const STAR_COUNT = 500;
 
-    function createStar() {
-        const star = document.createElement("div");
-        star.classList.add("star");
-        star.style.animationDuration = `${Math.random() * 3 + 2}s`;
-        star.style.opacity = Math.random();
-        return star;
-    }
-
-    function createPool() {
-        while (stars.length < STAR_COUNT) {
-            const star = createStar();
-            stars.push(star);
-            starsContainer.appendChild(star);
+    function generateStars() {
+        starsContainer.innerHTML = "";
+        const frag = document.createDocumentFragment();
+        for (let i = 0; i < STAR_COUNT; i++) {
+            const star = document.createElement("div");
+            star.classList.add("star");
+            star.style.left = `${Math.random() * window.innerWidth}px`;
+            star.style.top = `${Math.random() * window.innerHeight}px`;
+            star.style.animationDuration = `${Math.random() * 3 + 2}s`;
+            star.style.opacity = Math.random();
+            frag.appendChild(star);
         }
+        starsContainer.appendChild(frag);
     }
 
-    function positionStars() {
-        const w = window.innerWidth;
-        const h = window.innerHeight;
-        stars.forEach((star) => {
-            star.style.left = `${Math.random() * w}px`;
-            star.style.top = `${Math.random() * h}px`;
-        });
-    }
-
-    createPool();
-    positionStars();
+    generateStars();
 
     let resizeTimeout;
     window.addEventListener("resize", () => {
         clearTimeout(resizeTimeout);
-        resizeTimeout = setTimeout(() => {
-            positionStars();
-        }, 200);
+        resizeTimeout = setTimeout(generateStars, 200);
     });
 
     // Gradient colors

--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -3,30 +3,34 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!starsContainer) return;
 
     // Star generation
-    function generateStars() {
-        starsContainer.innerHTML = "";
-        // more stars by increasing density
-        const DENSITY = 4000;
-        const count = Math.floor((window.innerWidth * window.innerHeight) / DENSITY);
-        const frag = document.createDocumentFragment();
-        for (let i = 0; i < count; i++) {
-            const star = document.createElement("div");
-            star.classList.add("star");
-            star.style.left = `${Math.random() * window.innerWidth}px`;
-            star.style.top = `${Math.random() * window.innerHeight}px`;
-            star.style.animationDuration = `${Math.random() * 3 + 2}s`;
-            star.style.opacity = Math.random();
-            frag.appendChild(star);
-        }
-        starsContainer.appendChild(frag);
+    const stars = [];
+    const DENSITY = 4000;
+    const count = Math.floor((window.innerWidth * window.innerHeight) / DENSITY);
+
+    for (let i = 0; i < count; i++) {
+        const star = document.createElement("div");
+        star.classList.add("star");
+        star.style.animationDuration = `${Math.random() * 3 + 2}s`;
+        star.style.opacity = Math.random();
+        starsContainer.appendChild(star);
+        stars.push(star);
     }
 
-    generateStars();
+    function positionStars() {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        stars.forEach((star) => {
+            star.style.left = `${Math.random() * w}px`;
+            star.style.top = `${Math.random() * h}px`;
+        });
+    }
+
+    positionStars();
 
     let resizeTimeout;
     window.addEventListener("resize", () => {
         clearTimeout(resizeTimeout);
-        resizeTimeout = setTimeout(generateStars, 200);
+        resizeTimeout = setTimeout(positionStars, 200);
     });
 
     // Gradient colors

--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -5,15 +5,28 @@ document.addEventListener("DOMContentLoaded", () => {
     // Star generation
     const stars = [];
     const DENSITY = 4000;
-    const count = Math.floor((window.innerWidth * window.innerHeight) / DENSITY);
 
-    for (let i = 0; i < count; i++) {
+    function createStar() {
         const star = document.createElement("div");
         star.classList.add("star");
         star.style.animationDuration = `${Math.random() * 3 + 2}s`;
         star.style.opacity = Math.random();
-        starsContainer.appendChild(star);
-        stars.push(star);
+        return star;
+    }
+
+    function adjustStarCount() {
+        const required = Math.floor(
+            (window.innerWidth * window.innerHeight) / DENSITY,
+        );
+        while (stars.length < required) {
+            const star = createStar();
+            stars.push(star);
+            starsContainer.appendChild(star);
+        }
+        while (stars.length > required) {
+            const star = stars.pop();
+            if (star) star.remove();
+        }
     }
 
     function positionStars() {
@@ -25,12 +38,16 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     }
 
+    adjustStarCount();
     positionStars();
 
     let resizeTimeout;
     window.addEventListener("resize", () => {
         clearTimeout(resizeTimeout);
-        resizeTimeout = setTimeout(positionStars, 200);
+        resizeTimeout = setTimeout(() => {
+            adjustStarCount();
+            positionStars();
+        }, 200);
     });
 
     // Gradient colors

--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -3,8 +3,8 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!starsContainer) return;
 
     // Star generation
+    const STAR_COUNT = 2000;
     const stars = [];
-    const DENSITY = 4000;
 
     function createStar() {
         const star = document.createElement("div");
@@ -14,18 +14,11 @@ document.addEventListener("DOMContentLoaded", () => {
         return star;
     }
 
-    function adjustStarCount() {
-        const required = Math.floor(
-            (window.innerWidth * window.innerHeight) / DENSITY,
-        );
-        while (stars.length < required) {
+    function createPool() {
+        while (stars.length < STAR_COUNT) {
             const star = createStar();
             stars.push(star);
             starsContainer.appendChild(star);
-        }
-        while (stars.length > required) {
-            const star = stars.pop();
-            if (star) star.remove();
         }
     }
 
@@ -38,14 +31,13 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     }
 
-    adjustStarCount();
+    createPool();
     positionStars();
 
     let resizeTimeout;
     window.addEventListener("resize", () => {
         clearTimeout(resizeTimeout);
         resizeTimeout = setTimeout(() => {
-            adjustStarCount();
             positionStars();
         }, 200);
     });

--- a/client/scripts/background.js
+++ b/client/scripts/background.js
@@ -3,7 +3,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!starsContainer) return;
 
     // Star generation
-    const STAR_COUNT = 2000;
+    const STAR_COUNT = 250;
     const stars = [];
 
     function createStar() {

--- a/client/scripts/explore.js
+++ b/client/scripts/explore.js
@@ -7,18 +7,17 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!form || !result) return;
 
   function fadeOut(el) {
-    el.style.transition = 'opacity 500ms ease-out';
-    el.style.opacity = '0';
+    el.style.setProperty('--fade-duration', '500ms');
+    el.classList.remove('fade-in');
+    el.classList.add('fade-out');
     setTimeout(() => el.classList.add('hidden'), 500);
   }
 
   function fadeIn(el) {
     el.classList.remove('hidden');
-    el.style.opacity = '0';
-    requestAnimationFrame(() => {
-      el.style.transition = 'opacity 500ms ease-in';
-      el.style.opacity = '1';
-    });
+    el.style.setProperty('--fade-duration', '500ms');
+    el.classList.remove('fade-out');
+    el.classList.add('fade-in');
   }
 
   // realm names from src/data/realmMetadata.ts

--- a/client/scripts/ripple.js
+++ b/client/scripts/ripple.js
@@ -3,9 +3,13 @@
     const rect = element.getBoundingClientRect()
     // use a small, consistent ring size for smoother performance
     const size = 60
-    const ring = document.createElement('span')
-    ring.className = 'ripple'
-    ring.style.width = ring.style.height = `${size}px`
+    let ring = element.querySelector('span.ripple')
+    if (!ring) {
+      ring = document.createElement('span')
+      ring.className = 'ripple'
+      ring.style.width = ring.style.height = `${size}px`
+      element.appendChild(ring)
+    }
     ring.style.left = `${event.clientX - rect.left - size / 2}px`
     ring.style.top = `${event.clientY - rect.top - size / 2}px`
 
@@ -27,11 +31,13 @@
       ${hexWithAlpha(base, '00')} 55%)`
     ring.style.boxShadow = `0 0 6px ${hexWithAlpha(base, 'e6')}`
 
-    element.appendChild(ring)
+    ring.style.animation = 'none'
+    // trigger reflow to restart animation
+    void ring.offsetWidth
+    ring.style.animation = ''
     ring.addEventListener(
       'animationend',
       () => {
-        ring.remove()
         if (typeof onEnd === 'function') onEnd()
       },
       { once: true },

--- a/client/scripts/ui.js
+++ b/client/scripts/ui.js
@@ -32,23 +32,21 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function fadeOutElement(element, duration = 500) {
-    if (element) {
-      element.style.transition = `opacity ${duration}ms ease-out`
-      element.style.opacity = '0'
-      setTimeout(() => {
-        element.style.display = 'none'
-      }, duration)
-    }
+    if (!element) return
+    element.style.setProperty('--fade-duration', `${duration}ms`)
+    element.classList.remove('fade-in')
+    element.classList.add('fade-out')
+    setTimeout(() => {
+      element.style.display = 'none'
+    }, duration)
   }
 
   function fadeInElement(element, duration = 500) {
-    if (element) {
-      element.style.display = 'block'
-      setTimeout(() => {
-        element.style.transition = `opacity ${duration}ms ease-in`
-        element.style.opacity = '1'
-      }, 50)
-    }
+    if (!element) return
+    element.style.display = 'block'
+    element.style.setProperty('--fade-duration', `${duration}ms`)
+    element.classList.remove('fade-out')
+    element.classList.add('fade-in')
   }
 
   window.fadeInElement = fadeInElement
@@ -92,8 +90,8 @@ document.addEventListener('DOMContentLoaded', () => {
     loginButton.addEventListener('click', event => {
       event.preventDefault()
       sanitizeForm(loginForm)
-      stars.style.transition = 'opacity 1.5s ease-out'
-      stars.style.opacity = '0'
+      stars.style.setProperty('--fade-duration', '1500ms')
+      stars.classList.add('fade-out')
 
       const gradientOverlay = document.createElement('div')
       gradientOverlay.style.position = 'fixed'

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -159,6 +159,16 @@ h1 {
   animation: boxFloat 14s ease-in-out infinite;
 }
 
+body.realm-page {
+  --gradient-alpha: 0.85;
+}
+
+.realm-page .realm {
+  background: rgba(0, 0, 0, 0.6);
+  padding: 20px 10px;
+  border-radius: 12px;
+}
+
 .stellar-heading {
   letter-spacing: 2px;
   text-shadow: 0 0 6px rgba(255, 255, 255, 0.6);
@@ -721,7 +731,12 @@ fieldset legend {
 }
 
 #login-form input:not([type='checkbox']),
-#signup-form input:not([type='checkbox']),
+#signup-form input:not([type='checkbox']) {
+  width: calc(100% - 150px);
+  margin-left: auto;
+  margin-right: auto;
+}
+
 #login-form .submit-btn,
 #signup-form .submit-btn {
   width: 100%;
@@ -1145,7 +1160,7 @@ code {
 .realm-divider {
   border: 0;
   border-top: 1px solid rgba(255, 255, 255, 0.2);
-  margin: 30px 0;
+  margin: 12px 0;
   width: 90%;
 }
 

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -364,7 +364,7 @@ body.realm-page {
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
+  height: 100vh;
   background: black;
   pointer-events: none;
   opacity: 0;
@@ -404,7 +404,7 @@ body.realm-page {
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
+  height: 100vh;
   pointer-events: none;
   overflow: hidden;
   z-index: 0;
@@ -465,7 +465,7 @@ body.realm-page {
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
+  height:  100vh;
   pointer-events: none;
   will-change: transform;
 }
@@ -687,6 +687,8 @@ fieldset legend {
 }
 
 .form label {
+  display: block;
+  text-align: center;
   margin-bottom: 6px;
 }
 
@@ -732,7 +734,7 @@ fieldset legend {
 
 #login-form input:not([type='checkbox']),
 #signup-form input:not([type='checkbox']) {
-  width: calc(100% - 150px);
+  width: 240px;
   margin-left: auto;
   margin-right: auto;
 }
@@ -1160,7 +1162,7 @@ code {
 .realm-divider {
   border: 0;
   border-top: 1px solid rgba(255, 255, 255, 0.2);
-  margin: 12px 0;
+  margin: 6px 0;
   width: 90%;
 }
 

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -170,14 +170,25 @@ body.realm-page {
 }
 
 .stellar-heading {
+  color: #fff;
+  font-weight: 700;
+  line-height: 1.2;
+  text-align: center;
   letter-spacing: 2px;
-  text-shadow: 0 0 6px rgba(255, 255, 255, 0.6);
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
   background: linear-gradient(45deg, #ff8a00, #e52e71, #9b08ff);
   background-size: 400% 400%;
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
   animation: headerGradient 15s ease-in-out infinite;
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .stellar-heading {
+    -webkit-text-fill-color: currentColor;
+    background: none;
+  }
 }
 
 /* --------------------------
@@ -734,7 +745,7 @@ fieldset legend {
 
 #login-form input:not([type='checkbox']),
 #signup-form input:not([type='checkbox']) {
-  width: 240px;
+  width: 280px;
   margin-left: auto;
   margin-right: auto;
 }

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -476,7 +476,7 @@ body.realm-page {
   top: 0;
   left: 0;
   width: 100%;
-  height:  100vh;
+  height: 100%;
   pointer-events: none;
   will-change: transform;
 }

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -791,6 +791,19 @@ code {
   margin-right: 6px;
 }
 
+.fade-in,
+.fade-out {
+  transition: opacity var(--fade-duration, 500ms) ease;
+}
+
+.fade-in {
+  opacity: 1;
+}
+
+.fade-out {
+  opacity: 0;
+}
+
 .hidden {
   display: none;
 }

--- a/client/styles/universe.css
+++ b/client/styles/universe.css
@@ -66,8 +66,8 @@ body.universe-page {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 220px;
-  height: 220px;
+  width: 180px;
+  height: 180px;
   border-radius: 50%;
   color: #fff;
   display: flex;


### PR DESCRIPTION
## Summary
- keep a pool of stars and reposition them on resize
- add generic `.fade-in` and `.fade-out` classes
- toggle fade classes in JS instead of inline transitions
- reuse one ripple element per button

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6858d54c4e94832596109fa4d5431d2c